### PR TITLE
Audit: allow null FIEMAP without reflink support

### DIFF
--- a/scripts/audit-results.py
+++ b/scripts/audit-results.py
@@ -57,13 +57,15 @@ def null_ok(entity, key):
     if fs in CLASSIC:
         if key.startswith(("compress_", "snapscale")):
             return True
-        if key in ("reflink_ms", "divergence_clone_mbps") and fs == "ext4":
+        if key in ("reflink_ms", "reflink_fiemap_shared",
+                   "divergence_clone_mbps") and fs == "ext4":
             return True
         if not lvm and key in ("snapshot_create_ms", "snapshot_delete_ms",
                                "reclaim_s", "reclaim_write_mbps",
                                "divergence_snap_mbps"):
             return True
-    if fs == "zfs" and key in ("reflink_ms", "divergence_clone_mbps"):
+    if fs == "zfs" and key in ("reflink_ms", "reflink_fiemap_shared",
+                               "divergence_clone_mbps"):
         return True  # block cloning off by default
     return False
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -154,6 +154,36 @@ class AuditRegressionTests(unittest.TestCase):
             result.stdout,
         )
 
+    def test_fiemap_null_is_expected_without_reflink_support(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            shutil.copytree(FIXTURE_RUNS, runs)
+            for name in ("result-ext4-single.json", "result-zfs-mirror.json"):
+                shutil.copy2(runs / "100" / name, runs / "101" / name)
+
+            result = run_script(AUDIT, runs)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("audited 2 runs, 5 entities in latest", result.stdout)
+        self.assertIn("no anomalies found", result.stdout)
+
+    def test_fiemap_null_is_rejected_with_reflink_support(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            shutil.copytree(FIXTURE_RUNS, runs)
+            result_file = runs / "101" / "result-xfs-zvol.json"
+            document = json.loads(result_file.read_text())
+            document["results"]["reflink_fiemap_shared"] = None
+            result_file.write_text(json.dumps(document))
+
+            result = run_script(AUDIT, runs)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "xfs/zvol.reflink_fiemap_shared: unexpectedly null",
+            result.stdout,
+        )
+
 
 class ResultSchemaTests(unittest.TestCase):
     def test_manifest_preserves_dashboard_metric_contract(self):


### PR DESCRIPTION
## Summary
- treat `reflink_fiemap_shared: null` as expected for ext4 and ZFS, whose backends set `FS_REFLINK=0`
- retain the hard failure for reflink-capable XFS, btrfs, and bcachefs
- add positive and negative latest-run regression coverage

## Context
Fixes the 13 false hard anomalies in results-audit run 29568388577.

## Verification
- `python3 -m unittest discover -s tests -v` (9 tests pass)
- replayed the audit against the exact 97-run history from the failed workflow
- replay exits successfully with the existing warnings and no hard anomalies