### PR TITLE
Validate benchmark results before publication

### DIFF
--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -590,6 +590,7 @@ else
   SNAP_AVG=null
 fi
 
+RESULT_FILE="$RESULTS_DIR/result-$BENCH_ID.json"
 jq -n \
   --arg fs "$FS" \
   --arg layout "$LAYOUT" \
@@ -706,8 +707,9 @@ jq -n \
               scrub_found: $scrub_found,
               scrub_repaired: $scrub_repaired,
               data_intact: $data_intact}}' \
-  > "$RESULTS_DIR/result-$BENCH_ID.json"
+  > "$RESULT_FILE"
 
+python3 "$SCRIPT_DIR/validate-result.py" "$RESULT_FILE"
 chmod -R a+rX "$RESULTS_DIR"
-log "done: $RESULTS_DIR/result-$BENCH_ID.json"
-jq . "$RESULTS_DIR/result-$BENCH_ID.json" >&2
+log "done: $RESULT_FILE"
+jq . "$RESULT_FILE" >&2

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -13,6 +13,7 @@ DASHBOARD = ROOT / "scripts" / "make-dashboard.py"
 AUDIT = ROOT / "scripts" / "audit-results.py"
 SCHEMA = ROOT / "scripts" / "result-schema.json"
 VALIDATOR = ROOT / "scripts" / "validate-result.py"
+RUN_BENCH = ROOT / "scripts" / "run-bench.sh"
 
 METRIC_CONTRACT = [
     ("seqwrite_mbps", "Sequential write", "MB/s", "higher"),
@@ -241,6 +242,18 @@ class ResultSchemaTests(unittest.TestCase):
             "document.results: missing metrics: sparse_grow_bytes",
             result.stderr,
         )
+
+    def test_benchmark_validates_result_before_reporting_success(self):
+        source = RUN_BENCH.read_text()
+
+        write_result = source.index('> "$RESULT_FILE"')
+        validate_result = source.index(
+            'python3 "$SCRIPT_DIR/validate-result.py" "$RESULT_FILE"'
+        )
+        report_success = source.index('log "done: $RESULT_FILE"')
+
+        self.assertLess(write_result, validate_result)
+        self.assertLess(validate_result, report_success)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate each completed result JSON against `result-schema.json` before reporting benchmark success
- use one result path for creation, validation, logging, and final output
- add regression coverage that pins validation between file creation and the success log

## Failure behavior
A malformed result now fails the benchmark before publication. The JSON and raw outputs already written under `results/` remain available to the workflow's `if: always()` artifact upload for diagnosis.

## Production compatibility
Validated all 26 result files in the newest complete production run (`runs/115`) without changes.

## Testing
- `python3 -m unittest discover -s tests -v` (10 tests pass)
- `bash -n scripts/run-bench.sh`
- fixture validation (5 files)