### PR TITLE
xfs/zvol: leave pool space for snapshots

### DIFF
--- a/scripts/fs/xfs.sh
+++ b/scripts/fs/xfs.sh
@@ -20,10 +20,13 @@ fs_setup() {
       mirror "${DEVICES[2]}" "${DEVICES[3]}"
     # 75% of the pool: leaves room for snapshot divergence, and scales
     # down for the ENOSPC phase's small rebuild (a fixed size would hit
-    # pool-exhaustion EIO instead of clean filesystem ENOSPC)
+    # pool-exhaustion EIO instead of clean filesystem ENOSPC). The default
+    # refreservation=volsize makes the first snapshot fail once pre-aging
+    # writes consume the remaining pool headroom.
     local avail
     avail=$(zfs get -Hp -o value available "$ZPOOL")
-    zfs create -V "$(( avail * 3 / 4 ))" -o volblocksize=16k "$ZPOOL/zvol"
+    zfs create -V "$(( avail * 3 / 4 ))" -o volblocksize=16k \
+      -o refreservation=none "$ZPOOL/zvol"
     udevadm settle 2>/dev/null || sleep 2
     mkfs.xfs -fq "/dev/zvol/$ZPOOL/zvol"
     mount -o noatime "/dev/zvol/$ZPOOL/zvol" "$MNT"

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -14,6 +14,7 @@ AUDIT = ROOT / "scripts" / "audit-results.py"
 SCHEMA = ROOT / "scripts" / "result-schema.json"
 VALIDATOR = ROOT / "scripts" / "validate-result.py"
 RUN_BENCH = ROOT / "scripts" / "run-bench.sh"
+XFS_BACKEND = ROOT / "scripts" / "fs" / "xfs.sh"
 
 METRIC_CONTRACT = [
     ("seqwrite_mbps", "Sequential write", "MB/s", "higher"),
@@ -304,6 +305,13 @@ class ResultSchemaTests(unittest.TestCase):
 
         self.assertLess(write_result, validate_result)
         self.assertLess(validate_result, report_success)
+
+
+class BackendConfigurationTests(unittest.TestCase):
+    def test_xfs_zvol_does_not_reserve_space_needed_by_snapshots(self):
+        source = XFS_BACKEND.read_text()
+
+        self.assertIn("-o refreservation=none", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create the XFS zvol with `refreservation=none` while retaining its 75% size cap
- preserve the remaining pool space for snapshot divergence instead of reserving the full zvol size
- add regression coverage for the required zvol property

## Root cause
Capability validation exposed that all 29 historical `xfs/zvol` runs had null snapshot metrics. The latest job log shows the first aging snapshot failing with:

`cannot create snapshot 'fsbench/zvol@snap1': out of space`

A volume created with the default `refreservation=volsize` keeps its full logical size reserved. Once pre-aging writes consume the nominal headroom, ZFS cannot retain that reservation while snapshotting.

## Follow-up
After merge, a fresh XFS/zvol benchmark must confirm snapshot create/delete/reclaim/divergence metrics are populated before capability-based audit enforcement is enabled.

## Testing
- `python3 -m unittest discover -s tests -v` (14 tests pass)
- `bash -n scripts/fs/xfs.sh`