### PR TITLE
Record free space restored after snapshot reclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ scripts/result_schema.py   shared result schema loading and validation
 scripts/validate-result.py validates result JSON against that contract
 ```
 
+Result documents carry `schema_version`; historical unversioned documents are
+treated as version 1 so new metrics do not invalidate the stored history.
+
 Adding a filesystem = one file in `scripts/fs/` implementing `fs_setup`,
 `fs_snapshot`, and `fs_teardown`; everything else (`fs_setup_compression`,
 `fs_compress_ratio`, `fs_snapshot_delete_all`, `fs_remount`, `fs_snap_list`,

--- a/scripts/audit-results.py
+++ b/scripts/audit-results.py
@@ -142,7 +142,12 @@ def main():
                         and res["lat_load_ops"] < 20:
                     continue  # withheld by design below the 20-sample floor
                 if k == "reclaim_s":
-                    warn.append(f"{ent}: reclaim did not finish within 300s")
+                    pct = res.get("reclaim_free_pct")
+                    restored = (
+                        f"; {pct:.1f}% restored, target 85%"
+                        if isinstance(pct, (int, float)) else ""
+                    )
+                    warn.append(f"{ent}: reclaim did not finish within 300s{restored}")
                 else:
                     hard.append(f"{ent}.{k}: unexpectedly null")
 

--- a/scripts/result-schema.json
+++ b/scripts/result-schema.json
@@ -1,6 +1,7 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "document": {
+    "schema_version": {"type": "integer", "nonnegative": true, "required": false},
     "fs": {"type": "string", "nonempty": true},
     "layout": {"type": "string", "nonempty": true},
     "kernel": {"type": "string", "nonempty": true},
@@ -69,6 +70,7 @@
     {"key": "snapshot_delete_ms", "type": "number", "label": "Snapshot delete (all)", "unit": "ms", "better": "lower", "display": "card", "capability": "snapshots", "nullable": true, "nonnegative": true},
     {"key": "reclaim_s", "type": "number", "label": "Space reclaim after delete", "unit": "s", "better": "lower", "display": "card", "capability": "snapshots", "nullable": true, "nonnegative": true},
     {"key": "reclaim_write_mbps", "type": "number", "label": "Write during reclaim", "unit": "MB/s", "better": "higher", "display": "card", "capability": "snapshots", "nullable": true, "nonnegative": true},
+    {"key": "reclaim_free_pct", "type": "number", "label": "Free space restored after reclaim", "unit": "%", "display": "table", "capability": "snapshots", "nullable": true, "nonnegative": true, "introduced": 2},
     {"key": "compress_ratio", "type": "number", "label": "zstd compression ratio", "unit": "x", "better": "higher", "display": "card", "capability": "compression", "nullable": true, "nonnegative": true},
     {"key": "compress_write_mbps", "type": "number", "label": "Compressible-data write", "unit": "MB/s", "better": "higher", "display": "card", "capability": "compression", "nullable": true, "nonnegative": true},
     {"key": "reflink_ms", "type": "number", "label": "Reflink copy of 2G", "unit": "ms", "better": "lower", "display": "card", "capability": "reflink", "nullable": true, "nonnegative": true},

--- a/scripts/result_schema.py
+++ b/scripts/result_schema.py
@@ -74,7 +74,11 @@ def validate_document(document, schema, metrics):
 
     errors = []
     envelope = schema.get("document", {})
-    missing = sorted(set(envelope) - set(document))
+    required = {
+        key for key, spec in envelope.items()
+        if spec.get("required", True)
+    }
+    missing = sorted(required - set(document))
     if missing:
         errors.append(f"document: missing keys: {', '.join(missing)}")
 
@@ -85,7 +89,17 @@ def validate_document(document, schema, metrics):
             if not isinstance(results, dict):
                 errors.append(f"document.{key}: expected object, got {type(results).__name__}")
                 continue
-            missing_metrics = sorted(set(metrics) - set(results))
+            raw_version = document.get("schema_version", 1)
+            version = (
+                raw_version
+                if isinstance(raw_version, int) and not isinstance(raw_version, bool)
+                else 1
+            )
+            active_metrics = {
+                metric for metric, metric_spec in metrics.items()
+                if metric_spec.get("introduced", 1) <= version
+            }
+            missing_metrics = sorted(active_metrics - set(results))
             extra_metrics = sorted(set(results) - set(metrics))
             if missing_metrics:
                 errors.append(

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -278,6 +278,7 @@ done
 SNAP_DELETE_MS=null
 RECLAIM_S=null
 RECLAIM_WRITE_MBPS=null
+RECLAIM_FREE_PCT=null
 if [ "$SNAPSHOTS_OK" = 1 ] && [ "${#SNAP_MS[@]}" -gt 0 ]; then
   log "phase: delete $AGING_ITERS snapshots + reclaim"
   t0=$(now_ms)
@@ -290,15 +291,19 @@ if [ "$SNAPSHOTS_OK" = 1 ] && [ "${#SNAP_MS[@]}" -gt 0 ]; then
     # generations, metadata growth) — 90% missed by <1% in testing
     target=$(( FREE_BEFORE_AGING * 85 / 100 ))
     for i in $(seq 1 300); do
-      if [ "$(fs_free_bytes)" -ge "$target" ]; then
+      reclaim_free=$(fs_free_bytes)
+      if [ "$reclaim_free" -ge "$target" ]; then
         RECLAIM_S=$(( ($(now_ms) - t0) / 1000 ))
         break
       fi
       sleep 1
     done
+    reclaim_free=$(fs_free_bytes)
+    RECLAIM_FREE_PCT=$(jq -n --argjson free "$reclaim_free" \
+      --argjson before "$FREE_BEFORE_AGING" '$free * 100 / $before')
     [ "$RECLAIM_S" = null ] \
-      && log "space not back within 300s (free: $(( $(fs_free_bytes) / 1048576 ))M, target: $(( target / 1048576 ))M)"
-    log "snapshot delete: ${SNAP_DELETE_MS}ms, reclaim: ${RECLAIM_S}s"
+      && log "space not back within 300s (free: $(( reclaim_free / 1048576 ))M, target: $(( target / 1048576 ))M)"
+    log "snapshot delete: ${SNAP_DELETE_MS}ms, reclaim: ${RECLAIM_S}s (${RECLAIM_FREE_PCT}% restored)"
   else
     log "snapshot delete unsupported on $FS ($LAYOUT)"
   fi
@@ -620,6 +625,7 @@ jq -n \
   --argjson snapshot_delete_ms "$SNAP_DELETE_MS" \
   --argjson reclaim_s "$RECLAIM_S" \
   --argjson reclaim_write_mbps "$RECLAIM_WRITE_MBPS" \
+  --argjson reclaim_free_pct "$RECLAIM_FREE_PCT" \
   --argjson compress_ratio "$COMP_RATIO" \
   --argjson compress_write_mbps "$COMP_MBPS" \
   --argjson sparse_create_ms "$SPARSE_CREATE_MS" \
@@ -652,7 +658,8 @@ jq -n \
   --argjson data_intact "$DATA_INTACT" \
   --argjson calib_seqwrite_mbps "$CALIB_SEQ_MBPS" \
   --argjson calib_randwrite_iops "$CALIB_RAND_IOPS" \
-  '{fs: $fs, layout: $layout, kernel: $kernel, version: $version, date: $date,
+  '{schema_version: 2,
+    fs: $fs, layout: $layout, kernel: $kernel, version: $version, date: $date,
     devices: $devices, ndev: $ndev,
     calibration: {seqwrite_mbps: $calib_seqwrite_mbps,
                   randwrite_iops: $calib_randwrite_iops},
@@ -677,6 +684,7 @@ jq -n \
               snapshot_delete_ms: $snapshot_delete_ms,
               reclaim_s: $reclaim_s,
               reclaim_write_mbps: $reclaim_write_mbps,
+              reclaim_free_pct: $reclaim_free_pct,
               compress_ratio: $compress_ratio,
               compress_write_mbps: $compress_write_mbps,
               sparse_create_ms: $sparse_create_ms,

--- a/tests/fixtures/runs/101/result-bcachefs-replicas2.json
+++ b/tests/fixtures/runs/101/result-bcachefs-replicas2.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 2,
   "fs": "bcachefs",
   "layout": "replicas2",
   "kernel": "6.18.0-fixture",
@@ -29,6 +30,7 @@
     "snapshot_delete_ms": 45.0,
     "reclaim_s": 2,
     "reclaim_write_mbps": 40.0,
+    "reclaim_free_pct": 96.0,
     "compress_ratio": 3.6,
     "compress_write_mbps": 590.0,
     "sparse_create_ms": 0.3,

--- a/tests/fixtures/runs/101/result-btrfs-raid1.json
+++ b/tests/fixtures/runs/101/result-btrfs-raid1.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 2,
   "fs": "btrfs",
   "layout": "raid1",
   "kernel": "6.18.0-fixture",
@@ -29,6 +30,7 @@
     "snapshot_delete_ms": 18.0,
     "reclaim_s": 5,
     "reclaim_write_mbps": 35.0,
+    "reclaim_free_pct": 89.0,
     "compress_ratio": 3.8,
     "compress_write_mbps": 540.0,
     "sparse_create_ms": 0.4,

--- a/tests/fixtures/runs/101/result-xfs-zvol.json
+++ b/tests/fixtures/runs/101/result-xfs-zvol.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 2,
   "fs": "xfs",
   "layout": "zvol",
   "kernel": "6.18.0-fixture",
@@ -29,6 +30,7 @@
     "snapshot_delete_ms": 150.0,
     "reclaim_s": 4,
     "reclaim_write_mbps": 31.0,
+    "reclaim_free_pct": 92.0,
     "compress_ratio": 3.5,
     "compress_write_mbps": 570.0,
     "sparse_create_ms": 0.4,

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -274,13 +274,32 @@ class AuditRegressionTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("no anomalies found", result.stdout)
 
+    def test_reclaim_timeout_reports_restored_space(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runs = Path(tmp) / "runs"
+            shutil.copytree(FIXTURE_RUNS, runs)
+            result_file = runs / "101" / "result-btrfs-raid1.json"
+            document = json.loads(result_file.read_text())
+            document["results"]["reclaim_s"] = None
+            document["results"]["reclaim_free_pct"] = 82.4
+            result_file.write_text(json.dumps(document))
+
+            result = run_audit(runs)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "btrfs/raid1: reclaim did not finish within 300s; "
+            "82.4% restored, target 85%",
+            result.stdout,
+        )
+
 
 class ResultSchemaTests(unittest.TestCase):
     def test_manifest_preserves_dashboard_metric_contract(self):
         schema = json.loads(SCHEMA.read_text())
         metrics = schema["metrics"]
 
-        self.assertEqual(schema["schema_version"], 1)
+        self.assertEqual(schema["schema_version"], 2)
         self.assertEqual(
             [
                 (metric["key"], metric["label"], metric["unit"], metric["better"])
@@ -337,6 +356,31 @@ class ResultSchemaTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("validated 5 result file(s)", result.stdout)
+
+    def test_unversioned_results_use_v1_contract(self):
+        result = run_script(
+            VALIDATOR,
+            FIXTURE_RUNS / "100" / "result-ext4-single.json",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_schema_v2_requires_reclaim_telemetry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result_file = Path(tmp) / "result.json"
+            document = json.loads(
+                (FIXTURE_RUNS / "101" / "result-btrfs-raid1.json").read_text()
+            )
+            del document["results"]["reclaim_free_pct"]
+            result_file.write_text(json.dumps(document))
+
+            result = run_script(VALIDATOR, result_file)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "document.results: missing metrics: reclaim_free_pct",
+            result.stderr,
+        )
 
     def test_wrong_metric_type_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- record `reclaim_free_pct` after reclaim succeeds or reaches the 300-second timeout
- include restored percentage and the 85% target in timeout audit warnings
- emit schema version 2 from new benchmark results
- preserve unversioned historical results as schema version 1

## Why
`btrfs/single` repeatedly exceeds the reclaim window. The new normalized measurement distinguishes a near-threshold miss from genuinely stalled reclamation before changing the threshold or timeout.

## Schema compatibility
- `reclaim_free_pct` is introduced in schema v2 and required only for v2 documents
- existing unversioned production history remains valid as v1
- unsupported snapshot configurations continue to record null

## Verification
- replayed against 105 existing production runs with no new hard anomalies
- `python3 -m unittest discover -s tests -v` (22 tests pass)
- `bash -n scripts/run-bench.sh`
- fixture validator CLI (mixed unversioned v1 and v2 documents)