### PR TITLE
Dashboard: distinguish runs from trend points

### DIFF
--- a/scripts/make-dashboard.py
+++ b/scripts/make-dashboard.py
@@ -397,7 +397,9 @@ def main():
                     help="newest runs kept raw; older collapsed to daily medians")
     args = ap.parse_args()
 
-    runs = collapse_old(load_runs(args.runs), args.window)
+    raw_runs = load_runs(args.runs)
+    run_count = len(raw_runs)
+    runs = collapse_old(raw_runs, args.window)
     if not runs:
         print(f"no result JSON found under {args.runs}", file=sys.stderr)
         sys.exit(1)
@@ -429,6 +431,7 @@ def main():
             for k, l, u, b in METRICS
         ],
         "runs": runs,
+        "runCount": run_count,
         "repo": args.repo,
         "docs": {k: {"text": t, "src": [{"label": l, "url": SRC + p} for l, p in s]}
                  for k, (t, s) in DOCS.items()},
@@ -900,10 +903,12 @@ function buildTable(view) {
 // ---- filters + page assembly --------------------------------------------------
 const app = document.getElementById("app");
 const dt = (latest.date || "").replace("T", " ").replace("Z", " UTC");
+const runSummary = `${DATA.runCount} run${DATA.runCount === 1 ? "" : "s"} recorded` +
+  (DATA.runCount === DATA.runs.length ? "" : ` · ${DATA.runs.length} trend points shown`);
 app.appendChild(el("h1", {}, "modern-fs-benchmark"));
 app.appendChild(el("p", {class: "sub"},
   `Multi-device CoW filesystems under workloads classic benchmarks skip —
-   latest run ${dt}, kernel ${latest.kernel}, ${DATA.runs.length} run(s) recorded
+   latest run ${dt}, kernel ${latest.kernel}, ${runSummary}
    · <a href="${DATA.repo}">repository</a>`));
 app.appendChild(el("p", {class: "note"},
   "CI runs use loop devices on shared ephemeral VMs (one VM per filesystem): compare shapes and ratios, not absolute MB/s. Each job records a host-calibration anchor — see the table."));

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -102,6 +102,7 @@ class DashboardRegressionTests(unittest.TestCase):
 
         self.assertEqual(data["latest"]["date"], "2026-07-16T10:02:00Z")
         self.assertEqual(data["latest"]["kernel"], "6.18.0-fixture")
+        self.assertEqual(data["runCount"], 2)
         self.assertEqual(data["stale"], ["ext4/single", "zfs/mirror"])
         self.assertEqual(
             [entity["id"] for entity in data["entities"]],
@@ -134,6 +135,31 @@ class DashboardRegressionTests(unittest.TestCase):
             "tools 1.38.1 / module 1.38.1",
         )
         self.assertEqual(data["repo"], "https://example.test/fsbench")
+
+    def test_dashboard_distinguishes_runs_from_compacted_trend_points(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            runs = tmp / "runs"
+            shutil.copytree(FIXTURE_RUNS / "100", runs / "100")
+            shutil.copytree(FIXTURE_RUNS / "100", runs / "101")
+            shutil.copytree(FIXTURE_RUNS / "101", runs / "102")
+            output = tmp / "index.html"
+
+            result = run_script(
+                DASHBOARD,
+                "--runs",
+                runs,
+                "--out",
+                output,
+                "--window",
+                1,
+            )
+            data = dashboard_data(output.read_text())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(data["runCount"], 3)
+        self.assertEqual(len(data["runs"]), 2)
+        self.assertTrue(data["runs"][0]["agg"])
 
 
 class AuditRegressionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- preserve the raw result-directory count before daily trend compaction
- report recorded runs separately from displayed trend points
- add regression coverage for multiple old runs collapsing into one daily median

## Root cause
The live dashboard said `101 runs recorded` because it displayed `DATA.runs.length` after history compaction. The newest 100 runs stay raw and older runs collapse to daily medians, so 114 stored run directories became 101 chart points.

The highest run ID is 129, but IDs contain gaps from runs that produced no stored result directory; it is not the number of recorded runs.

## Result
The header will say, for example:

`114 runs recorded · 101 trend points shown`

Compaction and chart behavior remain unchanged.

## Testing
- `python3 -m unittest discover -s tests -v` (24 tests pass)
- fixture dashboard generation