### PR TITLE
CI: lint shell scripts with ShellCheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - name: Lint shell scripts
+        run: shellcheck --external-sources --source-path=SCRIPTDIR scripts/*.sh scripts/lib/*.sh scripts/fs/*.sh
+
   reporting:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/fs/bcachefs.sh
+++ b/scripts/fs/bcachefs.sh
@@ -3,6 +3,7 @@
 # The kernel module ships as DKMS (see install-deps.sh) since bcachefs
 # left mainline in 6.17.
 
+# shellcheck disable=SC2034  # consumed by run-bench.sh
 FS_REFLINK=1
 
 fs_setup() {

--- a/scripts/fs/btrfs.sh
+++ b/scripts/fs/btrfs.sh
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 # btrfs backend. Layout: raid1 data + metadata across all devices.
 
+# shellcheck disable=SC2034  # consumed by run-bench.sh
 FS_REFLINK=1
 
 fs_setup() {

--- a/scripts/fs/ext4.sh
+++ b/scripts/fs/ext4.sh
@@ -3,8 +3,10 @@
 # The single layout is the "what does any of this cost" anchor. Snapshots
 # come from LVM in the lvm layout; no compression, no reflink.
 
+# shellcheck source=../lib/layered.sh
 source "$SCRIPT_DIR/lib/layered.sh"
 
+# shellcheck disable=SC2034  # consumed by run-bench.sh
 FS_REFLINK=0
 
 fs_setup() {
@@ -20,6 +22,7 @@ fs_setup() {
   mkfs.ext4 -Fq "$LAYERED_DEV"
   mount -o noatime "$LAYERED_DEV" "$MNT"
   mkdir -p "$MNT/data"
+  # shellcheck disable=SC2034  # consumed by run-bench.sh
   DATA="$MNT/data"
 }
 

--- a/scripts/fs/xfs.sh
+++ b/scripts/fs/xfs.sh
@@ -3,8 +3,10 @@
 # Unlike ext4, XFS has reflink (on by default in mkfs.xfs), so it joins the
 # CoW filesystems in that column. Snapshots come from LVM in the lvm layout.
 
+# shellcheck source=../lib/layered.sh
 source "$SCRIPT_DIR/lib/layered.sh"
 
+# shellcheck disable=SC2034  # consumed by run-bench.sh
 FS_REFLINK=1
 
 ZPOOL=fsbench
@@ -38,6 +40,7 @@ fs_setup() {
   mkfs.xfs -fq "$LAYERED_DEV"
   mount -o noatime "$LAYERED_DEV" "$MNT"
   mkdir -p "$MNT/data"
+  # shellcheck disable=SC2034  # consumed by run-bench.sh
   DATA="$MNT/data"
 }
 

--- a/scripts/fs/zfs.sh
+++ b/scripts/fs/zfs.sh
@@ -2,6 +2,7 @@
 # ZFS backend. Layout "mirror": striped mirror pairs (raid10-like) —
 # devices are paired in order, so pass an even number of devices.
 
+# shellcheck disable=SC2034  # consumed by run-bench.sh
 FS_REFLINK=0  # block cloning exists in 2.2+ but is off by default; revisit
 POOL=fsbench
 
@@ -45,6 +46,7 @@ fs_setup() {
   zpool create -f -O mountpoint="$MNT" -O compression=off -O atime=off \
     "${extra[@]}" "$POOL" "${vdevs[@]}"
   zfs create "$POOL/data"
+  # shellcheck disable=SC2034  # consumed by run-bench.sh
   DATA="$MNT/data"
 }
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -29,6 +29,7 @@ case "$FS" in
     install -d -m 0755 /etc/apt/keyrings
     wget -qO /etc/apt/keyrings/apt.bcachefs.org.asc https://apt.bcachefs.org/apt.bcachefs.org.asc
     chmod 0644 /etc/apt/keyrings/apt.bcachefs.org.asc
+    # shellcheck source=/dev/null
     codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
     cat > /etc/apt/sources.list.d/apt.bcachefs.org.sources <<EOF
 Types: deb

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -83,6 +83,7 @@ luks_wrap_top() {
   [ -f "$keyfile" ] || dd if=/dev/urandom of="$keyfile" bs=64 count=1 status=none
   cryptsetup luksFormat -q --type luks2 --key-file "$keyfile" "$1"
   cryptsetup open --key-file "$keyfile" "$1" "$name"
+  # shellcheck disable=SC2034  # consumed by layered filesystem backends
   LUKS_TOP_DEV="/dev/mapper/$name"
 }
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -90,7 +90,9 @@ luks_wrap_top() {
 luks_close_all() {
   local m
   for m in /dev/mapper/fsbench-luks-*; do
-    [ -e "$m" ] && cryptsetup close "${m##*/}" 2>/dev/null || true
+    if [ -e "$m" ]; then
+      cryptsetup close "${m##*/}" 2>/dev/null || true
+    fi
   done
 }
 

--- a/scripts/lib/layered.sh
+++ b/scripts/lib/layered.sh
@@ -57,6 +57,7 @@ EOF
       case "$LAYOUT" in *-int) integrity=(--raidintegrity y) ;; esac
       lvcreate --type raid10 -i $(( ${#DEVICES[@]} / 2 )) -m 1 --nosync \
         "${integrity[@]}" -l 50%FREE -n bench -y "$VG"
+      # shellcheck disable=SC2034  # consumed by filesystem backends
       LAYERED_DEV="/dev/$VG/bench"
       ;;
     *)

--- a/scripts/lib/layered.sh
+++ b/scripts/lib/layered.sh
@@ -218,7 +218,9 @@ layered_teardown() {
       vgremove -fy "$VG" 2>/dev/null || true
       local d
       for d in /dev/mapper/fsbench-pv*; do
-        [ -e "$d" ] && dmsetup remove "${d##*/}" 2>/dev/null || true
+        if [ -e "$d" ]; then
+          dmsetup remove "${d##*/}" 2>/dev/null || true
+        fi
       done
       ;;
   esac

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -10,6 +10,7 @@
 # Emits $RESULTS_DIR/result-<fs>-<layout>.json plus raw fio output.
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
 FS=${1:?usage: run-bench.sh <fs> <layout>}
@@ -17,6 +18,8 @@ LAYOUT=${2:?usage: run-bench.sh <fs> <layout>}
 BENCH_ID="$FS-$LAYOUT"
 
 [ -f "$SCRIPT_DIR/fs/$FS.sh" ] || die "unknown filesystem: $FS"
+# The selected backend is checked separately by the ShellCheck CI job.
+# shellcheck source=/dev/null
 source "$SCRIPT_DIR/fs/$FS.sh"
 
 require_root
@@ -366,6 +369,7 @@ if [[ "$FS" =~ ^(btrfs|zfs|bcachefs)$ || "$LAYOUT" == lvm-* ]]; then
     SNAPSCALE_DELETE_MS=$(( $(now_ms) - t0 ))
   fi
   log "snapscale: $SNAPSCALE_N snaps in ${SNAPSCALE_TOTAL_S}s, create@tail ${SNAPSCALE_CREATE_MS}ms, list ${SNAPSCALE_LIST_MS}ms, remount ${SNAPSCALE_REMOUNT_MS}ms, delete ${SNAPSCALE_DELETE_MS}ms"
+  # shellcheck disable=SC2034  # consumed by layered snapshot backends
   LVM_SNAP_SIZE=2G  # aging/divergence snapshots go back to full size
 fi
 


### PR DESCRIPTION
## Summary
- add a dedicated ShellCheck job to the test workflow
- follow statically known sourced files during analysis
- document narrow cross-file globals instead of disabling checks globally

## Testing
- `shellcheck --external-sources --source-path=SCRIPTDIR scripts/*.sh scripts/lib/*.sh scripts/fs/*.sh`
- `python3 -m unittest discover -s tests -v` (24 passed)