### PR TITLE
Publish only complete benchmark result sets

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -169,6 +169,11 @@ jobs:
           path: incoming
           merge-multiple: true
 
+      # Failed matrix attempts may still reach publish; keep their partial
+      # artifacts out of history until a retry supplies the full matrix.
+      - name: Validate complete result set
+        run: python3 scripts/validate-result.py --complete-set incoming/result-*.json
+
       - name: Append results to history branch
         run: |
           git config user.name "github-actions[bot]"

--- a/scripts/validate-result.py
+++ b/scripts/validate-result.py
@@ -2,6 +2,7 @@
 """Validate benchmark result JSON against the current result contract."""
 
 import argparse
+import collections
 import json
 import sys
 from pathlib import Path
@@ -13,6 +14,11 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("files", nargs="+", type=Path)
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument(
+        "--complete-set",
+        action="store_true",
+        help="require exactly one result for every configured matrix entity",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -22,6 +28,7 @@ def main(argv=None):
         return 2
 
     failed = False
+    entities = []
     for path in args.files:
         try:
             with path.open() as fh:
@@ -30,13 +37,47 @@ def main(argv=None):
             print(f"{path}: invalid JSON: {exc}", file=sys.stderr)
             failed = True
             continue
+        fs = document.get("fs") if isinstance(document, dict) else None
+        layout = document.get("layout") if isinstance(document, dict) else None
+        if isinstance(fs, str) and isinstance(layout, str):
+            entities.append(f"{fs}/{layout}")
         for error in validate_document(document, schema, metrics):
             print(f"{path}: {error}", file=sys.stderr)
             failed = True
 
+    if args.complete_set:
+        configurations = schema.get("configurations")
+        if not isinstance(configurations, dict):
+            print("schema.configurations must be an object", file=sys.stderr)
+            return 2
+        counts = collections.Counter(entities)
+        expected = set(configurations)
+        missing = sorted(expected - set(counts))
+        unexpected = sorted(set(counts) - expected)
+        duplicates = sorted(entity for entity, count in counts.items() if count > 1)
+        if missing:
+            print(
+                f"result set missing configurations: {', '.join(missing)}",
+                file=sys.stderr,
+            )
+            failed = True
+        if unexpected:
+            print(
+                f"result set has unknown configurations: {', '.join(unexpected)}",
+                file=sys.stderr,
+            )
+            failed = True
+        if duplicates:
+            print(
+                f"result set has duplicate configurations: {', '.join(duplicates)}",
+                file=sys.stderr,
+            )
+            failed = True
+
     if failed:
         return 1
-    print(f"validated {len(args.files)} result file(s)")
+    suffix = " as a complete matrix" if args.complete_set else ""
+    print(f"validated {len(args.files)} result file(s){suffix}")
     return 0
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -393,6 +393,22 @@ class AuditRegressionTests(unittest.TestCase):
 
 
 class ResultSchemaTests(unittest.TestCase):
+    def write_complete_result_set(self, directory):
+        configurations = json.loads(SCHEMA.read_text())["configurations"]
+        template = json.loads(
+            (FIXTURE_RUNS / "101" / "result-btrfs-raid1.json").read_text()
+        )
+        paths = []
+        for entity in configurations:
+            fs, layout = entity.split("/", 1)
+            document = template.copy()
+            document["fs"] = fs
+            document["layout"] = layout
+            path = Path(directory) / f"result-{fs}-{layout}.json"
+            path.write_text(json.dumps(document))
+            paths.append(path)
+        return paths
+
     def test_manifest_preserves_dashboard_metric_contract(self):
         schema = json.loads(SCHEMA.read_text())
         metrics = schema["metrics"]
@@ -454,6 +470,62 @@ class ResultSchemaTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("validated 5 result file(s)", result.stdout)
+
+    def test_complete_result_set_is_accepted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self.write_complete_result_set(tmp)
+
+            result = run_script(VALIDATOR, "--complete-set", *paths)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            f"validated {len(paths)} result file(s) as a complete matrix",
+            result.stdout,
+        )
+
+    def test_incomplete_result_set_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self.write_complete_result_set(tmp)
+            missing = paths.pop()
+            missing_document = json.loads(missing.read_text())
+            missing_entity = (
+                f"{missing_document['fs']}/{missing_document['layout']}"
+            )
+            missing.unlink()
+
+            result = run_script(VALIDATOR, "--complete-set", *paths)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            f"result set missing configurations: {missing_entity}",
+            result.stderr,
+        )
+
+    def test_duplicate_result_configuration_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self.write_complete_result_set(tmp)
+            duplicate = Path(tmp) / "duplicate.json"
+            shutil.copy2(paths[0], duplicate)
+
+            result = run_script(VALIDATOR, "--complete-set", *paths, duplicate)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            "result set has duplicate configurations: ext4/single",
+            result.stderr,
+        )
+
+    def test_history_publication_requires_complete_result_set(self):
+        workflow = BENCH_WORKFLOW.read_text()
+
+        validation = workflow.index("Validate complete result set")
+        publication = workflow.index("Append results to history branch")
+
+        self.assertLess(validation, publication)
+        self.assertIn(
+            "validate-result.py --complete-set incoming/result-*.json",
+            workflow,
+        )
 
     def test_unversioned_results_use_v1_contract(self):
         result = run_script(


### PR DESCRIPTION
## Summary
- add `--complete-set` validation for exact benchmark matrix membership
- reject missing, unknown, and duplicate configurations
- validate downloaded artifacts before touching the results history branch
- prevent failed attempts from exposing partial latest runs to the dashboard or audit

## Incident addressed
Run 142 published 24/26 artifacts during retry 2. The scheduled audit observed that intermediate commit before retry 3 supplied the missing results. With this gate, retry 2 would fail before history publication and retry 3 would publish the complete set atomically.

## Testing
- `python3 -m unittest discover -s tests -v` (31 passed)
- ShellCheck passed
- normal single-result validation passed
- complete-set validation passed against the actual 26 files in results run 142