### PR TITLE
Diagnose bcachefs EC evacuation stalls

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -157,9 +157,6 @@ jobs:
     concurrency:
       group: pages
       cancel-in-progress: false
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
 
@@ -215,5 +212,17 @@ jobs:
         with:
           path: site
 
+  deploy:
+    name: Deploy dashboard
+    needs: publish
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/repro-bcachefs-ec.yml
+++ b/.github/workflows/repro-bcachefs-ec.yml
@@ -7,9 +7,6 @@ on:
         description: 'Wait for pending EC reconcile before offlining a member'
         type: boolean
         default: false
-  # Temporary branch trigger used to validate the reproducer before merge.
-  push:
-    branches: [fix/bcachefs-ec-evacuation]
 
 permissions:
   contents: read
@@ -36,6 +33,7 @@ jobs:
             WORK_ROOT=/mnt \
             REPRO_ATTEMPT=${{ matrix.attempt }} \
             RECONCILE_BEFORE_DEGRADE=${{ inputs.reconcile_before_degrade && '1' || '0' }} \
+            BCACHEFS_RECONCILE_TIMEOUT=5m \
             BCACHEFS_EVAC_DIAG_AFTER=180 \
             BCACHEFS_EVAC_TIMEOUT=10m \
             scripts/repro-bcachefs-ec-evacuate.sh

--- a/.github/workflows/repro-bcachefs-ec.yml
+++ b/.github/workflows/repro-bcachefs-ec.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       reconcile_before_degrade:
-        description: 'Wait for pending EC reconcile before offlining a member'
+        description: 'Drive IO while waiting for EC reconcile before device loss'
         type: boolean
         default: false
 
@@ -34,6 +34,7 @@ jobs:
             REPRO_ATTEMPT=${{ matrix.attempt }} \
             RECONCILE_BEFORE_DEGRADE=${{ inputs.reconcile_before_degrade && '1' || '0' }} \
             BCACHEFS_RECONCILE_TIMEOUT=5m \
+            RECONCILE_DRIVER_RUNTIME=300 \
             BCACHEFS_EVAC_DIAG_AFTER=180 \
             BCACHEFS_EVAC_TIMEOUT=10m \
             scripts/repro-bcachefs-ec-evacuate.sh

--- a/.github/workflows/repro-bcachefs-ec.yml
+++ b/.github/workflows/repro-bcachefs-ec.yml
@@ -1,0 +1,49 @@
+name: reproduce-bcachefs-ec-evacuation
+
+on:
+  workflow_dispatch:
+    inputs:
+      reconcile_before_degrade:
+        description: 'Wait for pending EC reconcile before offlining a member'
+        type: boolean
+        default: false
+  # Temporary branch trigger used to validate the reproducer before merge.
+  push:
+    branches: [fix/bcachefs-ec-evacuation]
+
+permissions:
+  contents: read
+
+jobs:
+  reproduce:
+    name: attempt ${{ matrix.attempt }}
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        attempt: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install bcachefs
+        run: sudo scripts/install-deps.sh bcachefs
+
+      - name: Run minimal EC evacuation reproducer
+        run: |
+          sudo env \
+            OUTPUT_DIR="$PWD/repro-output" \
+            WORK_ROOT=/mnt \
+            REPRO_ATTEMPT=${{ matrix.attempt }} \
+            RECONCILE_BEFORE_DEGRADE=${{ inputs.reconcile_before_degrade && '1' || '0' }} \
+            BCACHEFS_EVAC_DIAG_AFTER=180 \
+            BCACHEFS_EVAC_TIMEOUT=10m \
+            scripts/repro-bcachefs-ec-evacuate.sh
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bcachefs-ec-evacuation-${{ matrix.attempt }}
+          path: repro-output/
+          if-no-files-found: warn

--- a/.github/workflows/repro-bcachefs-ec.yml
+++ b/.github/workflows/repro-bcachefs-ec.yml
@@ -2,11 +2,6 @@ name: reproduce-bcachefs-ec-evacuation
 
 on:
   workflow_dispatch:
-    inputs:
-      reconcile_before_degrade:
-        description: 'Drive IO while waiting for EC reconcile before device loss'
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -32,9 +27,6 @@ jobs:
             OUTPUT_DIR="$PWD/repro-output" \
             WORK_ROOT=/mnt \
             REPRO_ATTEMPT=${{ matrix.attempt }} \
-            RECONCILE_BEFORE_DEGRADE=${{ inputs.reconcile_before_degrade && '1' || '0' }} \
-            BCACHEFS_RECONCILE_TIMEOUT=5m \
-            RECONCILE_DRIVER_RUNTIME=300 \
             BCACHEFS_EVAC_DIAG_AFTER=180 \
             BCACHEFS_EVAC_TIMEOUT=10m \
             scripts/repro-bcachefs-ec-evacuate.sh

--- a/docs/bcachefs-ec-evacuation-reproducer.md
+++ b/docs/bcachefs-ec-evacuation-reproducer.md
@@ -34,6 +34,39 @@ moving contexts stop making progress. Existing benchmark artifacts prove the
 blocking command but do not contain enough kernel state to establish that both
 failures have the same cause.
 
+## Reduced reproduction result
+
+The first four-attempt run of the standalone case reproduced the stall once:
+
+- [workflow run 29740996573](https://github.com/fenio/modern-fs-benchmark/actions/runs/29740996573)
+- [failed attempt](https://github.com/fenio/modern-fs-benchmark/actions/runs/29740996573/job/88347471981)
+- [diagnostic artifact](https://github.com/fenio/modern-fs-benchmark/actions/runs/29740996573/artifacts/8460769148)
+
+Three identical attempts completed successfully. The fourth moved 3.97 GiB in
+about 90 seconds, reached exactly 2.69 MiB, then remained unchanged until the
+10-minute command timeout.
+
+The live diagnostic snapshot showed:
+
+- bcachefs tools and module 1.38.8 on kernel 7.0.0-1009-azure
+- the reconcile thread in uninterruptible sleep in
+  `__bch2_closure_sync_timeout` from `do_reconcile`
+- two `reconcile_work` moving contexts with zero bytes and zero IO in flight
+- the evacuating member retaining 708 KiB user data and 2 MiB parity
+- 789 MiB pending EC reconcile and 708 KiB high-priority replica work
+- one 2+2 stripe in flight
+- only 4 MiB of 799 MiB EC stripe-buffer memory in use
+
+The last point does not match the stripe-buffer exhaustion reported in issue
+#1182. This may be a different reconcile/evacuation forward-progress bug, or a
+second path to the same closure wait. The captured artifact is intended to let
+upstream distinguish those cases.
+
+A preliminary four-attempt control with `RECONCILE_BEFORE_DEGRADE=1` had one
+successful wait and three timeouts before any member was offlined. That points
+to an EC reconcile problem independent of device evacuation. The reproducer
+captures a full diagnostic snapshot when this optional barrier times out.
+
 ## Standalone reproducer
 
 The script creates five disposable 16 GiB sparse loop devices, formats four as
@@ -104,8 +137,11 @@ Each attempt records:
 > evacuation on a four-device 2+2 EC filesystem. The test offlines one member,
 > performs 30 seconds of 4 KiB random writes and reads while degraded, brings
 > the member online, adds a fifth device, then evacuates the original member.
-> Evacuation normally moves about 3.48 GiB in 57 seconds. In repeated failures,
-> it reaches 332-900 KiB remaining and stays there for more than 45 minutes.
-> Identical fresh-runner retries sometimes pass. This resembles issue #1182;
-> the attached bundle includes reconcile status, new_stripes, moving contexts,
-> blocked tasks, pressure, and the kernel log captured while stalled.
+> The standalone case reproduced on its first four-attempt run: three attempts
+> passed and one moved 3.97 GiB, stopped at exactly 2.69 MiB, and timed out after
+> ten minutes. At the stall, bch-reconcile was in D state in
+> __bch2_closure_sync_timeout from do_reconcile; moving contexts showed no IO in
+> flight; the member retained 708 KiB user data plus 2 MiB parity. Unlike issue
+> #1182, internal/new_stripes showed only 4 MiB of 799 MiB stripe-buffer memory
+> in use. The attached bundle includes usage, reconcile status, new_stripes,
+> moving contexts, blocked tasks, pressure, and the kernel log.

--- a/docs/bcachefs-ec-evacuation-reproducer.md
+++ b/docs/bcachefs-ec-evacuation-reproducer.md
@@ -1,0 +1,111 @@
+# bcachefs EC evacuation stall reproducer
+
+## Observed failure
+
+The benchmark intermittently stalls while replacing one member of a four-device
+bcachefs EC filesystem. The exact command is:
+
+```sh
+bcachefs device evacuate /dev/loop1
+```
+
+The command normally migrates about 3.48 GiB and finishes in roughly one minute.
+On failing runs it reaches a small remainder, then reports the same value until
+the 60-minute GitHub Actions job timeout:
+
+- 332 KiB remaining for 2,802 samples
+- 584 KiB remaining for 2,807 samples
+- 900 KiB remaining for 2,775 samples
+
+The host calibration is normal on these attempts. The filesystem uses bcachefs
+tools and module 1.38.8 on kernel 7.0.0-1009-azure.
+
+Examples:
+
+- [run 29724829904, attempt 1](https://github.com/fenio/modern-fs-benchmark/actions/runs/29724829904/job/88295417320)
+- [run 29724829904, attempt 2](https://github.com/fenio/modern-fs-benchmark/actions/runs/29724829904/job/88307306495)
+- [run 29696521649, timed-out attempt](https://github.com/fenio/modern-fs-benchmark/actions/runs/29696521649/job/88220237414)
+- [run 29716072546, successful control](https://github.com/fenio/modern-fs-benchmark/actions/runs/29716072546/job/88273318813)
+
+The closest known report is
+[koverstreet/bcachefs#1182](https://github.com/koverstreet/bcachefs/issues/1182),
+where EC reconcile wedges after stripe-buffer memory exceeds its limit and
+moving contexts stop making progress. Existing benchmark artifacts prove the
+blocking command but do not contain enough kernel state to establish that both
+failures have the same cause.
+
+## Standalone reproducer
+
+The script creates five disposable 16 GiB sparse loop devices, formats four as
+a 2+2 EC filesystem with replicas=3, generates sequential and 4 KiB random
+write churn, offlines one member, writes and reads while degraded, adds the
+fifth loop as a spare, and evacuates the original member.
+
+It never accepts or modifies real block devices.
+
+```sh
+sudo scripts/install-deps.sh bcachefs
+sudo OUTPUT_DIR="$PWD/repro-output" \
+  scripts/repro-bcachefs-ec-evacuate.sh
+```
+
+Expected success: evacuation completes in about one minute.
+
+Observed failure signature: evacuation drops below 1 MiB remaining and makes
+no further progress. The default command timeout is 12 minutes, with a live
+diagnostic snapshot after three minutes.
+
+Useful controls:
+
+```sh
+# Test whether completing pending EC work prevents the stall.
+sudo RECONCILE_BEFORE_DEGRADE=1 \
+  OUTPUT_DIR="$PWD/repro-with-reconcile" \
+  scripts/repro-bcachefs-ec-evacuate.sh
+
+# Override diagnostic and command timeouts.
+sudo BCACHEFS_EVAC_DIAG_AFTER=60 BCACHEFS_EVAC_TIMEOUT=5m \
+  OUTPUT_DIR="$PWD/repro-fast" \
+  scripts/repro-bcachefs-ec-evacuate.sh
+```
+
+The manual `reproduce-bcachefs-ec-evacuation` workflow runs four independent
+attempts and uploads each diagnostic bundle even when evacuation times out.
+
+The full workload that originally exposed the failure remains available as a
+control:
+
+```sh
+sudo DEV_SIZE=16G AGING_ITERS=100 AGING_IO=64M SNAPSCALE_COUNT=500 \
+  RESULTS_DIR="$PWD/results" scripts/run-bench.sh bcachefs ec
+```
+
+## Captured evidence
+
+Each attempt records:
+
+- kernel, tools, and module versions
+- fio seed, churn, and degraded-I/O JSON
+- full evacuation progress
+- `bcachefs fs usage -a -h`
+- `bcachefs reconcile status`
+- `reconcile_status`
+- `internal/moving_ctxts`
+- `internal/new_stripes`
+- `internal/alloc_debug`, when available
+- `ec_stripe_buf_limit` and `move_bytes_in_flight`
+- IO and memory pressure
+- bcachefs process stacks
+- SysRq blocked-task report and `dmesg` on a stall
+
+## Upstream report draft
+
+> bcachefs 1.38.8 intermittently stops making progress during device
+> evacuation on a four-device 2+2 EC filesystem. The test offlines one member,
+> performs 30 seconds of 4 KiB random writes and reads while degraded, brings
+> the member online, adds a fifth device, then evacuates the original member.
+> Evacuation normally moves about 3.48 GiB in 57 seconds. In repeated failures,
+> it reaches 332-900 KiB remaining and stays there for more than 45 minutes.
+> Identical fresh-runner retries sometimes pass. This resembles issue #1182;
+> the attached bundle includes reconcile status, new_stripes, moving contexts,
+> blocked tasks, pressure, and the kernel log captured while stalled.

--- a/docs/bcachefs-ec-evacuation-reproducer.md
+++ b/docs/bcachefs-ec-evacuation-reproducer.md
@@ -62,10 +62,11 @@ The last point does not match the stripe-buffer exhaustion reported in issue
 second path to the same closure wait. The captured artifact is intended to let
 upstream distinguish those cases.
 
-A preliminary four-attempt control with `RECONCILE_BEFORE_DEGRADE=1` had one
-successful wait and three timeouts before any member was offlined. That points
-to an EC reconcile problem independent of device evacuation. The reproducer
-captures a full diagnostic snapshot when this optional barrier times out.
+An initial passive `RECONCILE_BEFORE_DEGRADE=1` control was invalid: three
+waits timed out because bcachefs reported an IO-clock wait while the test was
+idle. The current control drives direct reads during the optional barrier so
+the IO clock advances. It captures a full diagnostic snapshot if reconcile
+still fails to drain.
 
 ## Standalone reproducer
 

--- a/docs/bcachefs-ec-evacuation-reproducer.md
+++ b/docs/bcachefs-ec-evacuation-reproducer.md
@@ -62,11 +62,13 @@ The last point does not match the stripe-buffer exhaustion reported in issue
 second path to the same closure wait. The captured artifact is intended to let
 upstream distinguish those cases.
 
-An initial passive `RECONCILE_BEFORE_DEGRADE=1` control was invalid: three
-waits timed out because bcachefs reported an IO-clock wait while the test was
-idle. The current control drives direct reads during the optional barrier so
-the IO clock advances. It captures a full diagnostic snapshot if reconcile
-still fails to drain.
+Two attempted pre-degrade `bcachefs reconcile wait` controls were discarded:
+[run 29746041465](https://github.com/fenio/modern-fs-benchmark/actions/runs/29746041465)
+and [run 29748213670](https://github.com/fenio/modern-fs-benchmark/actions/runs/29748213670).
+The remaining normal-priority EC work was tied to an open stripe and the
+reconcile thread was deliberately rate-limited on the write IO clock. Those
+timeouts occurred before any member was offlined, but do not establish an
+independent reconcile bug or a safe barrier before device loss.
 
 ## Standalone reproducer
 
@@ -89,15 +91,9 @@ Observed failure signature: evacuation drops below 1 MiB remaining and makes
 no further progress. The default command timeout is 12 minutes, with a live
 diagnostic snapshot after three minutes.
 
-Useful controls:
+Timeout override:
 
 ```sh
-# Test whether completing pending EC work prevents the stall.
-sudo RECONCILE_BEFORE_DEGRADE=1 \
-  OUTPUT_DIR="$PWD/repro-with-reconcile" \
-  scripts/repro-bcachefs-ec-evacuate.sh
-
-# Override diagnostic and command timeouts.
 sudo BCACHEFS_EVAC_DIAG_AFTER=60 BCACHEFS_EVAC_TIMEOUT=5m \
   OUTPUT_DIR="$PWD/repro-fast" \
   scripts/repro-bcachefs-ec-evacuate.sh

--- a/scripts/fs/bcachefs.sh
+++ b/scripts/fs/bcachefs.sh
@@ -6,6 +6,9 @@
 # shellcheck disable=SC2034  # consumed by run-bench.sh
 FS_REFLINK=1
 
+# shellcheck source=../lib/bcachefs-debug.sh
+source "$SCRIPT_DIR/lib/bcachefs-debug.sh"
+
 fs_setup() {
   modprobe bcachefs 2>/dev/null || true
   grep -qw bcachefs /proc/filesystems \
@@ -154,9 +157,18 @@ fs_degrade() {
 }
 
 fs_rebuild() {
-  bcachefs device online "${DEVICES[1]}"
-  bcachefs device add "$MNT" "$SPARE_DEV"
-  bcachefs device evacuate "${DEVICES[1]}"
+  bcachefs device online "${DEVICES[1]}" \
+    || die "failed to bring ${DEVICES[1]} online before rebuild"
+  bcachefs device add "$MNT" "$SPARE_DEV" \
+    || die "failed to add rebuild spare $SPARE_DEV"
+  if [ "${LAYOUT:-replicas2}" = ec ]; then
+    if ! bcachefs_evacuate_with_diagnostics \
+         "$MNT" "${DEVICES[1]}" "$RESULTS_DIR/raw/$BENCH_ID-evacuate"; then
+      die "bcachefs EC evacuation failed or timed out"
+    fi
+  elif ! bcachefs device evacuate "${DEVICES[1]}"; then
+    die "bcachefs evacuation failed"
+  fi
 }
 
 fs_teardown() {

--- a/scripts/lib/bcachefs-debug.sh
+++ b/scripts/lib/bcachefs-debug.sh
@@ -1,0 +1,115 @@
+# shellcheck shell=bash
+# Diagnostic helpers shared by the bcachefs backend and EC reproducer.
+
+bcachefs_debug_section() {
+  printf '\n===== %s =====\n' "$1"
+}
+
+bcachefs_debug_dump() { # <output> <mountpoint> [dump-blocked-tasks]
+  local output=$1 mountpoint=$2 dump_blocked=${3:-0}
+  (
+    set +e
+    umask 022
+    mkdir -p "$(dirname "$output")"
+    exec >"$output" 2>&1
+
+    bcachefs_debug_section "identity"
+    date -u +%FT%TZ
+    uname -a
+    bcachefs version
+    modinfo bcachefs
+
+    bcachefs_debug_section "mount and devices"
+    findmnt "$mountpoint"
+    lsblk -o NAME,PATH,SIZE,TYPE,FSTYPE,MOUNTPOINTS
+
+    bcachefs_debug_section "filesystem usage"
+    timeout 15s bcachefs fs usage -a -h "$mountpoint"
+
+    bcachefs_debug_section "reconcile status"
+    timeout 15s bcachefs reconcile status "$mountpoint"
+
+    local fsdir path
+    for fsdir in /sys/fs/bcachefs/*; do
+      [ -d "$fsdir" ] || continue
+      for path in \
+        reconcile_status \
+        internal/moving_ctxts \
+        internal/new_stripes \
+        internal/alloc_debug \
+        options/ec_stripe_buf_limit \
+        options/move_bytes_in_flight; do
+        [ -r "$fsdir/$path" ] || continue
+        bcachefs_debug_section "$fsdir/$path"
+        timeout 15s cat "$fsdir/$path"
+      done
+    done
+
+    bcachefs_debug_section "pressure and memory"
+    cat /proc/pressure/io
+    cat /proc/pressure/memory
+    cat /proc/meminfo
+
+    bcachefs_debug_section "bcachefs processes"
+    ps -e -o pid,ppid,stat,wchan:32,comm,args
+    local proc comm
+    for proc in /proc/[0-9]*; do
+      [ -r "$proc/comm" ] || continue
+      read -r comm < "$proc/comm"
+      case "$comm" in
+        bch-*|bcachefs*)
+          bcachefs_debug_section "$proc ($comm)"
+          cat "$proc/status"
+          cat "$proc/wchan"
+          cat "$proc/stack"
+          ;;
+      esac
+    done
+
+    if [ "$dump_blocked" = 1 ] && [ -w /proc/sysrq-trigger ]; then
+      bcachefs_debug_section "blocked tasks requested through sysrq-w"
+      printf w > /proc/sysrq-trigger
+      sleep 1
+    fi
+
+    bcachefs_debug_section "kernel log"
+    dmesg --color=never
+  )
+}
+
+bcachefs_evacuate_with_diagnostics() { # <mountpoint> <device> <output-prefix>
+  local mountpoint=$1 device=$2 prefix=$3
+  local evac_timeout=${BCACHEFS_EVAC_TIMEOUT:-12m}
+  local diag_after=${BCACHEFS_EVAC_DIAG_AFTER:-180}
+  local marker="${prefix}.done" watchdog rc
+
+  mkdir -p "$(dirname "$prefix")"
+  rm -f "$marker"
+  bcachefs_debug_dump "${prefix}-before.txt" "$mountpoint" 0
+
+  (
+    sleep "$diag_after"
+    if [ ! -e "$marker" ]; then
+      bcachefs_debug_dump "${prefix}-stalled.txt" "$mountpoint" 1
+    fi
+  ) &
+  watchdog=$!
+
+  if timeout --signal=TERM --kill-after=30s "$evac_timeout" \
+       bcachefs device evacuate "$device" 2>&1 \
+       | tee "${prefix}.log"; then
+    rc=0
+  else
+    rc=${PIPESTATUS[0]}
+  fi
+
+  : > "$marker"
+  kill "$watchdog" 2>/dev/null || true
+  wait "$watchdog" 2>/dev/null || true
+  rm -f "$marker"
+
+  if [ "$rc" -ne 0 ]; then
+    bcachefs_debug_dump "${prefix}-failed.txt" "$mountpoint" 1
+  fi
+  return "$rc"
+}

--- a/scripts/repro-bcachefs-ec-evacuate.sh
+++ b/scripts/repro-bcachefs-ec-evacuate.sh
@@ -23,6 +23,7 @@ SEED_SIZE=${SEED_SIZE:-7G}
 CHURN_RUNTIME=${CHURN_RUNTIME:-120}
 DEGRADED_RUNTIME=${DEGRADED_RUNTIME:-30}
 RECONCILE_BEFORE_DEGRADE=${RECONCILE_BEFORE_DEGRADE:-0}
+BCACHEFS_RECONCILE_TIMEOUT=${BCACHEFS_RECONCILE_TIMEOUT:-5m}
 
 mkdir -p "$WORK_ROOT" "$OUTPUT_DIR"
 WORK_DIR=$(mktemp -d "$WORK_ROOT/bcachefs-ec-evacuate.XXXXXX")
@@ -83,8 +84,21 @@ fio --output-format=json --output="$OUTPUT_DIR/fio-churn.json" \
 
 if [ "$RECONCILE_BEFORE_DEGRADE" = 1 ]; then
   log "wait for EC reconcile before device loss"
-  timeout 10m bcachefs reconcile wait -t erasure_code "$MNT" \
-    || timeout 10m bcachefs reconcile wait "$MNT"
+  bcachefs_debug_dump "$OUTPUT_DIR/reconcile-wait-before.txt" "$MNT" 0
+  reconcile_rc=0
+  timeout --signal=TERM --kill-after=30s "$BCACHEFS_RECONCILE_TIMEOUT" \
+    bcachefs reconcile wait -t erasure_code "$MNT" || reconcile_rc=$?
+  if [ "$reconcile_rc" -ne 0 ] && [ "$reconcile_rc" -ne 124 ] \
+     && [ "$reconcile_rc" -ne 137 ]; then
+    log "typed reconcile wait exited $reconcile_rc; try generic syntax"
+    reconcile_rc=0
+    timeout --signal=TERM --kill-after=30s "$BCACHEFS_RECONCILE_TIMEOUT" \
+      bcachefs reconcile wait "$MNT" || reconcile_rc=$?
+  fi
+  if [ "$reconcile_rc" -ne 0 ]; then
+    bcachefs_debug_dump "$OUTPUT_DIR/reconcile-wait-failed.txt" "$MNT" 1
+    die "EC reconcile wait failed or timed out with status $reconcile_rc"
+  fi
 fi
 
 bcachefs_debug_dump "$OUTPUT_DIR/before-offline.txt" "$MNT" 0

--- a/scripts/repro-bcachefs-ec-evacuate.sh
+++ b/scripts/repro-bcachefs-ec-evacuate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Reproduce an intermittent bcachefs EC device-evacuation stall on five
+# disposable loop devices. No real block devices are accepted or modified.
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=lib/bcachefs-debug.sh
+source "$SCRIPT_DIR/lib/bcachefs-debug.sh"
+
+log() { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+die() { log "ERROR: $*" >&2; exit 1; }
+
+[ "$(id -u)" -eq 0 ] || die "must run as root"
+for command in bcachefs fio losetup mount mountpoint timeout truncate umount; do
+  command -v "$command" >/dev/null || die "missing command: $command"
+done
+grep -qw bcachefs /proc/filesystems || die "kernel has no bcachefs support"
+
+WORK_ROOT=${WORK_ROOT:-/var/tmp}
+OUTPUT_DIR=${OUTPUT_DIR:-$PWD/bcachefs-ec-evacuate-output}
+DEVICE_SIZE=${DEVICE_SIZE:-16G}
+SEED_SIZE=${SEED_SIZE:-7G}
+CHURN_RUNTIME=${CHURN_RUNTIME:-120}
+DEGRADED_RUNTIME=${DEGRADED_RUNTIME:-30}
+RECONCILE_BEFORE_DEGRADE=${RECONCILE_BEFORE_DEGRADE:-0}
+
+mkdir -p "$WORK_ROOT" "$OUTPUT_DIR"
+WORK_DIR=$(mktemp -d "$WORK_ROOT/bcachefs-ec-evacuate.XXXXXX")
+MNT="$WORK_DIR/mnt"
+DATA="$MNT/data"
+mkdir -p "$MNT"
+declare -a LOOPS=()
+
+exec > >(tee -a "$OUTPUT_DIR/reproducer.log") 2>&1
+
+cleanup() {
+  set +e
+  log "cleanup"
+  if mountpoint -q "$MNT"; then
+    timeout 30s umount "$MNT"
+  fi
+  if mountpoint -q "$MNT"; then
+    log "mount is still busy; preserving $WORK_DIR and its loop devices"
+  else
+    local device
+    for device in "${LOOPS[@]}"; do
+      losetup -d "$device" 2>/dev/null || true
+    done
+    rm -rf "$WORK_DIR"
+  fi
+  chmod -R a+rX "$OUTPUT_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+log "kernel: $(uname -r)"
+log "tools: $(bcachefs version 2>/dev/null | head -1)"
+log "module: $(modinfo -F version bcachefs 2>/dev/null | head -1)"
+log "attempt: ${REPRO_ATTEMPT:-manual}"
+
+for i in 0 1 2 3 4; do
+  truncate -s "$DEVICE_SIZE" "$WORK_DIR/dev$i.img"
+  LOOPS+=("$(losetup --find --show "$WORK_DIR/dev$i.img")")
+done
+log "loops: ${LOOPS[*]}"
+
+bcachefs format -f --erasure_code --replicas=3 \
+  "${LOOPS[0]}" "${LOOPS[1]}" "${LOOPS[2]}" "${LOOPS[3]}"
+
+printf -v DEVLIST '%s:' "${LOOPS[@]:0:4}"
+DEVLIST=${DEVLIST%:}
+mount -t bcachefs "$DEVLIST" "$MNT"
+bcachefs subvolume create "$DATA"
+
+log "seed $SEED_SIZE of foreground data"
+fio --output-format=json --output="$OUTPUT_DIR/fio-seed.json" \
+  --name=seed --filename="$DATA/seed.dat" --rw=write --bs=1M \
+  --size="$SEED_SIZE" --end_fsync=1
+
+log "churn seed with 4k random writes for ${CHURN_RUNTIME}s"
+fio --output-format=json --output="$OUTPUT_DIR/fio-churn.json" \
+  --name=churn --filename="$DATA/seed.dat" --rw=randwrite --bs=4k \
+  --size="$SEED_SIZE" --runtime="$CHURN_RUNTIME" --time_based --fdatasync=16
+
+if [ "$RECONCILE_BEFORE_DEGRADE" = 1 ]; then
+  log "wait for EC reconcile before device loss"
+  timeout 10m bcachefs reconcile wait -t erasure_code "$MNT" \
+    || timeout 10m bcachefs reconcile wait "$MNT"
+fi
+
+bcachefs_debug_dump "$OUTPUT_DIR/before-offline.txt" "$MNT" 0
+
+log "offline ${LOOPS[1]}"
+bcachefs device offline --force "${LOOPS[1]}" \
+  || bcachefs device offline "${LOOPS[1]}"
+
+log "degraded 4k random write for ${DEGRADED_RUNTIME}s"
+fio --output-format=json --output="$OUTPUT_DIR/fio-degraded-write.json" \
+  --name=degraded-write --directory="$DATA" --rw=randwrite --bs=4k \
+  --size=1G --runtime="$DEGRADED_RUNTIME" --time_based --fdatasync=16
+
+log "degraded 4k random read for ${DEGRADED_RUNTIME}s"
+fio --output-format=json --output="$OUTPUT_DIR/fio-degraded-read.json" \
+  --name=degraded-read --filename="$DATA/seed.dat" --rw=randread --bs=4k \
+  --size="$SEED_SIZE" --runtime="$DEGRADED_RUNTIME" --time_based
+
+log "online ${LOOPS[1]} and add spare ${LOOPS[4]}"
+bcachefs device online "${LOOPS[1]}" || die "failed to online original device"
+bcachefs device add "$MNT" "${LOOPS[4]}" || die "failed to add spare device"
+
+log "evacuate ${LOOPS[1]}"
+if bcachefs_evacuate_with_diagnostics \
+     "$MNT" "${LOOPS[1]}" "$OUTPUT_DIR/evacuate"; then
+  bcachefs_debug_dump "$OUTPUT_DIR/evacuate-success.txt" "$MNT" 0
+  log "evacuation completed"
+else
+  rc=$?
+  log "evacuation failed or timed out with status $rc"
+  exit "$rc"
+fi

--- a/scripts/repro-bcachefs-ec-evacuate.sh
+++ b/scripts/repro-bcachefs-ec-evacuate.sh
@@ -22,9 +22,6 @@ DEVICE_SIZE=${DEVICE_SIZE:-16G}
 SEED_SIZE=${SEED_SIZE:-7G}
 CHURN_RUNTIME=${CHURN_RUNTIME:-120}
 DEGRADED_RUNTIME=${DEGRADED_RUNTIME:-30}
-RECONCILE_BEFORE_DEGRADE=${RECONCILE_BEFORE_DEGRADE:-0}
-BCACHEFS_RECONCILE_TIMEOUT=${BCACHEFS_RECONCILE_TIMEOUT:-5m}
-RECONCILE_DRIVER_RUNTIME=${RECONCILE_DRIVER_RUNTIME:-300}
 
 mkdir -p "$WORK_ROOT" "$OUTPUT_DIR"
 WORK_DIR=$(mktemp -d "$WORK_ROOT/bcachefs-ec-evacuate.XXXXXX")
@@ -32,17 +29,12 @@ MNT="$WORK_DIR/mnt"
 DATA="$MNT/data"
 mkdir -p "$MNT"
 declare -a LOOPS=()
-RECONCILE_DRIVER_PID=
 
 exec > >(tee -a "$OUTPUT_DIR/reproducer.log") 2>&1
 
 cleanup() {
   set +e
   log "cleanup"
-  if [ -n "$RECONCILE_DRIVER_PID" ]; then
-    kill "$RECONCILE_DRIVER_PID" 2>/dev/null || true
-    wait "$RECONCILE_DRIVER_PID" 2>/dev/null || true
-  fi
   if mountpoint -q "$MNT"; then
     timeout 30s umount "$MNT"
   fi
@@ -87,33 +79,6 @@ log "churn seed with 4k random writes for ${CHURN_RUNTIME}s"
 fio --output-format=json --output="$OUTPUT_DIR/fio-churn.json" \
   --name=churn --filename="$DATA/seed.dat" --rw=randwrite --bs=4k \
   --size="$SEED_SIZE" --runtime="$CHURN_RUNTIME" --time_based --fdatasync=16
-
-if [ "$RECONCILE_BEFORE_DEGRADE" = 1 ]; then
-  log "drive the IO clock while waiting for EC reconcile before device loss"
-  bcachefs_debug_dump "$OUTPUT_DIR/reconcile-wait-before.txt" "$MNT" 0
-  fio --output-format=json --output="$OUTPUT_DIR/fio-reconcile-driver.json" \
-    --name=reconcile-driver --filename="$DATA/seed.dat" --rw=read --bs=1M \
-    --size="$SEED_SIZE" --runtime="$RECONCILE_DRIVER_RUNTIME" --time_based \
-    --direct=1 &
-  RECONCILE_DRIVER_PID=$!
-  reconcile_rc=0
-  timeout --signal=TERM --kill-after=30s "$BCACHEFS_RECONCILE_TIMEOUT" \
-    bcachefs reconcile wait -t erasure_code "$MNT" || reconcile_rc=$?
-  if [ "$reconcile_rc" -ne 0 ] && [ "$reconcile_rc" -ne 124 ] \
-     && [ "$reconcile_rc" -ne 137 ]; then
-    log "typed reconcile wait exited $reconcile_rc; try generic syntax"
-    reconcile_rc=0
-    timeout --signal=TERM --kill-after=30s "$BCACHEFS_RECONCILE_TIMEOUT" \
-      bcachefs reconcile wait "$MNT" || reconcile_rc=$?
-  fi
-  kill "$RECONCILE_DRIVER_PID" 2>/dev/null || true
-  wait "$RECONCILE_DRIVER_PID" 2>/dev/null || true
-  RECONCILE_DRIVER_PID=
-  if [ "$reconcile_rc" -ne 0 ]; then
-    bcachefs_debug_dump "$OUTPUT_DIR/reconcile-wait-failed.txt" "$MNT" 1
-    die "EC reconcile wait failed or timed out with status $reconcile_rc"
-  fi
-fi
 
 bcachefs_debug_dump "$OUTPUT_DIR/before-offline.txt" "$MNT" 0
 

--- a/scripts/repro-bcachefs-ec-evacuate.sh
+++ b/scripts/repro-bcachefs-ec-evacuate.sh
@@ -24,6 +24,7 @@ CHURN_RUNTIME=${CHURN_RUNTIME:-120}
 DEGRADED_RUNTIME=${DEGRADED_RUNTIME:-30}
 RECONCILE_BEFORE_DEGRADE=${RECONCILE_BEFORE_DEGRADE:-0}
 BCACHEFS_RECONCILE_TIMEOUT=${BCACHEFS_RECONCILE_TIMEOUT:-5m}
+RECONCILE_DRIVER_RUNTIME=${RECONCILE_DRIVER_RUNTIME:-300}
 
 mkdir -p "$WORK_ROOT" "$OUTPUT_DIR"
 WORK_DIR=$(mktemp -d "$WORK_ROOT/bcachefs-ec-evacuate.XXXXXX")
@@ -31,12 +32,17 @@ MNT="$WORK_DIR/mnt"
 DATA="$MNT/data"
 mkdir -p "$MNT"
 declare -a LOOPS=()
+RECONCILE_DRIVER_PID=
 
 exec > >(tee -a "$OUTPUT_DIR/reproducer.log") 2>&1
 
 cleanup() {
   set +e
   log "cleanup"
+  if [ -n "$RECONCILE_DRIVER_PID" ]; then
+    kill "$RECONCILE_DRIVER_PID" 2>/dev/null || true
+    wait "$RECONCILE_DRIVER_PID" 2>/dev/null || true
+  fi
   if mountpoint -q "$MNT"; then
     timeout 30s umount "$MNT"
   fi
@@ -83,8 +89,13 @@ fio --output-format=json --output="$OUTPUT_DIR/fio-churn.json" \
   --size="$SEED_SIZE" --runtime="$CHURN_RUNTIME" --time_based --fdatasync=16
 
 if [ "$RECONCILE_BEFORE_DEGRADE" = 1 ]; then
-  log "wait for EC reconcile before device loss"
+  log "drive the IO clock while waiting for EC reconcile before device loss"
   bcachefs_debug_dump "$OUTPUT_DIR/reconcile-wait-before.txt" "$MNT" 0
+  fio --output-format=json --output="$OUTPUT_DIR/fio-reconcile-driver.json" \
+    --name=reconcile-driver --filename="$DATA/seed.dat" --rw=read --bs=1M \
+    --size="$SEED_SIZE" --runtime="$RECONCILE_DRIVER_RUNTIME" --time_based \
+    --direct=1 &
+  RECONCILE_DRIVER_PID=$!
   reconcile_rc=0
   timeout --signal=TERM --kill-after=30s "$BCACHEFS_RECONCILE_TIMEOUT" \
     bcachefs reconcile wait -t erasure_code "$MNT" || reconcile_rc=$?
@@ -95,6 +106,9 @@ if [ "$RECONCILE_BEFORE_DEGRADE" = 1 ]; then
     timeout --signal=TERM --kill-after=30s "$BCACHEFS_RECONCILE_TIMEOUT" \
       bcachefs reconcile wait "$MNT" || reconcile_rc=$?
   fi
+  kill "$RECONCILE_DRIVER_PID" 2>/dev/null || true
+  wait "$RECONCILE_DRIVER_PID" 2>/dev/null || true
+  RECONCILE_DRIVER_PID=
   if [ "$reconcile_rc" -ne 0 ]; then
     bcachefs_debug_dump "$OUTPUT_DIR/reconcile-wait-failed.txt" "$MNT" 1
     die "EC reconcile wait failed or timed out with status $reconcile_rc"

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -16,7 +16,13 @@ SCHEMA = ROOT / "scripts" / "result-schema.json"
 VALIDATOR = ROOT / "scripts" / "validate-result.py"
 RUN_BENCH = ROOT / "scripts" / "run-bench.sh"
 XFS_BACKEND = ROOT / "scripts" / "fs" / "xfs.sh"
+BCACHEFS_BACKEND = ROOT / "scripts" / "fs" / "bcachefs.sh"
+BCACHEFS_DEBUG = ROOT / "scripts" / "lib" / "bcachefs-debug.sh"
+BCACHEFS_REPRO = ROOT / "scripts" / "repro-bcachefs-ec-evacuate.sh"
 BENCH_WORKFLOW = ROOT / ".github" / "workflows" / "bench.yml"
+BCACHEFS_REPRO_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "repro-bcachefs-ec.yml"
+)
 
 METRIC_CONTRACT = [
     ("seqwrite_mbps", "Sequential write", "MB/s", "higher"),
@@ -547,6 +553,7 @@ class ResultSchemaTests(unittest.TestCase):
             "validate-result.py --complete-set incoming/result-*.json",
             workflow,
         )
+        self.assertIn("name: Deploy dashboard\n    needs: publish", workflow)
 
     def test_unversioned_results_use_v1_contract(self):
         result = run_script(
@@ -765,6 +772,37 @@ class BackendConfigurationTests(unittest.TestCase):
         source = XFS_BACKEND.read_text()
 
         self.assertIn("-o refreservation=none", source)
+
+    def test_bcachefs_ec_evacuation_is_bounded_and_diagnostic(self):
+        backend = BCACHEFS_BACKEND.read_text()
+        debug = BCACHEFS_DEBUG.read_text()
+
+        self.assertIn("bcachefs_evacuate_with_diagnostics", backend)
+        self.assertIn('die "bcachefs EC evacuation failed or timed out"', backend)
+        for evidence in (
+            "bcachefs reconcile status",
+            "internal/moving_ctxts",
+            "internal/new_stripes",
+            "options/ec_stripe_buf_limit",
+            "options/move_bytes_in_flight",
+            "/proc/sysrq-trigger",
+            "dmesg --color=never",
+        ):
+            self.assertIn(evidence, debug)
+
+    def test_standalone_bcachefs_ec_reproducer_matches_failure_path(self):
+        reproducer = BCACHEFS_REPRO.read_text()
+        workflow = BCACHEFS_REPRO_WORKFLOW.read_text()
+
+        for command in (
+            "bcachefs format -f --erasure_code --replicas=3",
+            "bcachefs device offline --force",
+            "bcachefs device add",
+            "bcachefs_evacuate_with_diagnostics",
+        ):
+            self.assertIn(command, reproducer)
+        self.assertIn("workflow_dispatch", workflow)
+        self.assertIn("if: always()", workflow)
 
 
 if __name__ == "__main__":

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -796,21 +796,12 @@ class BackendConfigurationTests(unittest.TestCase):
 
         for command in (
             "bcachefs format -f --erasure_code --replicas=3",
-            "--name=reconcile-driver",
-            "--rw=read",
-            "--direct=1",
-            "bcachefs reconcile wait -t erasure_code",
             "bcachefs device offline --force",
             "bcachefs device add",
             "bcachefs_evacuate_with_diagnostics",
         ):
             self.assertIn(command, reproducer)
-        self.assertLess(
-            reproducer.index("--name=reconcile-driver"),
-            reproducer.index("bcachefs reconcile wait -t erasure_code"),
-        )
         self.assertIn("workflow_dispatch", workflow)
-        self.assertIn("RECONCILE_DRIVER_RUNTIME=300", workflow)
         self.assertIn("if: always()", workflow)
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -796,12 +796,21 @@ class BackendConfigurationTests(unittest.TestCase):
 
         for command in (
             "bcachefs format -f --erasure_code --replicas=3",
+            "--name=reconcile-driver",
+            "--rw=read",
+            "--direct=1",
+            "bcachefs reconcile wait -t erasure_code",
             "bcachefs device offline --force",
             "bcachefs device add",
             "bcachefs_evacuate_with_diagnostics",
         ):
             self.assertIn(command, reproducer)
+        self.assertLess(
+            reproducer.index("--name=reconcile-driver"),
+            reproducer.index("bcachefs reconcile wait -t erasure_code"),
+        )
         self.assertIn("workflow_dispatch", workflow)
+        self.assertIn("RECONCILE_DRIVER_RUNTIME=300", workflow)
         self.assertIn("if: always()", workflow)
 
 


### PR DESCRIPTION
## Summary
- bound bcachefs EC device evacuation and capture live kernel/reconcile diagnostics before timeout
- add a five-loop standalone reproducer plus a four-attempt manual workflow and upstream report draft
- deploy Pages only after complete benchmark publication succeeds
- document the reproduced 2.69 MiB stall and discard misleading pre-degrade reconcile controls

## Verification
- `python3 -m unittest discover -s tests -p 'test_*.py'` (36 tests)
- `shellcheck scripts/lib/bcachefs-debug.sh scripts/repro-bcachefs-ec-evacuate.sh scripts/fs/bcachefs.sh`
- `bash -n scripts/lib/bcachefs-debug.sh scripts/repro-bcachefs-ec-evacuate.sh scripts/fs/bcachefs.sh`
- `actionlint -ignore 'label "ubuntu-26.04" is unknown'`
- `git diff --check`
- reduced reproducer run: https://github.com/fenio/modern-fs-benchmark/actions/runs/29740996573 (3 passed, 1 evacuation stall)