### PR TITLE
CI: add managed hardware benchmark runner

### DIFF
--- a/.github/workflows/bench-real-hw.yml
+++ b/.github/workflows/bench-real-hw.yml
@@ -1,29 +1,23 @@
-name: fs-bench
+name: fs-bench-real-hw
 
 on:
-  push:
-    branches: [main]
-    # docs-only commits must not trigger (or, via the concurrency group,
-    # CANCEL) benchmark runs - a README push once killed a 23-job run
-    paths-ignore:
-      - '**.md'
   schedule:
-    - cron: '17 */2 * * *'  # every 2 hours at :17 (GitHub may delay/skip under load)
+    # The suite writes roughly 1.7 TB per run; keep hardware wear bounded.
+    - cron: '43 3 * * 0'
   workflow_dispatch:
 
-# A newer push supersedes older push runs (their code is stale anyway);
-# cron/dispatch runs keep unique groups and never cancel each other.
 concurrency:
-  group: fs-bench-${{ github.event_name == 'push' && 'push' || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  group: fs-bench-real-hw
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
   bench:
-    runs-on: ubuntu-26.04
-    timeout-minutes: 60
+    if: github.event_name == 'workflow_dispatch' || vars.ENABLE_HARDWARE_BENCHMARKS == 'true'
+    runs-on: [self-hosted, linux, x64, fs-benchmark]
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -34,9 +28,6 @@ jobs:
             layout: md-raid10
           - fs: ext4
             layout: lvm-raid10
-            # dm-snapshot copies each origin write into every snapshot
-            # lacking it, and each snapshot pre-allocates VG space — 100
-            # old-style LVM snapshots is unusable by design
             aging_iters: 8
           - fs: xfs
             layout: single
@@ -61,26 +52,19 @@ jobs:
             layout: single
           - fs: zfs
             layout: mirror
-            # 128K recordsize pins ~the whole aging file per snapshot —
-            # ~10 snapshots is what this pool size honestly affords
             aging_iters: 10
           - fs: zfs
             layout: mirror-8k
           - fs: zfs
             layout: single
-            # one device = 16G usable; 128K-recordsize snapshot retention
-            # needs more or the pool exhausts mid-aging
             dev_size: 32G
             aging_iters: 10
           - fs: zfs
             layout: raidz2
-            # default recordsize — same snapshot-retention math as mirror
             aging_iters: 10
           - fs: zfs
             layout: raidz1
             aging_iters: 10
-          # raidz + native encryption (community request): parity math and
-          # AES-256-GCM stack, vs mirror-enc which pays only the crypto
           - fs: zfs
             layout: raidz1-enc
             aging_iters: 10
@@ -93,7 +77,6 @@ jobs:
             layout: single
           - fs: bcachefs
             layout: ec
-          # encryption variants: native vs one-LUKS-per-device vs LUKS-over-raid
           - fs: zfs
             layout: mirror-enc
             aging_iters: 10
@@ -108,20 +91,24 @@ jobs:
       AGING_ITERS: ${{ matrix.aging_iters || '100' }}
       AGING_IO: 64M
       SNAPSCALE_COUNT: 500
-      # fail fast on slow shared VMs (normal runners: ~400 MB/s, ~14.5k IOPS)
       CALIB_MIN_SEQ_MBPS: 300
       CALIB_MIN_RAND_IOPS: 8000
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install dependencies
-        run: sudo scripts/install-deps.sh ${{ matrix.fs }}
-
-      - name: Run benchmark
+      - name: Run benchmark through managed wrapper
         run: |
-          sudo --preserve-env=DEV_SIZE,AGING_ITERS,AGING_IO,SNAPSCALE_COUNT,CALIB_MIN_SEQ_MBPS,CALIB_MIN_RAND_IOPS \
-            RESULTS_DIR="$PWD/results" \
-            scripts/run-bench.sh ${{ matrix.fs }} ${{ matrix.layout }}
+          runner=$(command -v modern-fs-benchmark-run) || {
+            echo 'managed benchmark wrapper is not installed' >&2
+            exit 1
+          }
+          sudo "$runner" \
+            "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" \
+            "${{ matrix.fs }}" "${{ matrix.layout }}" \
+            "$DEV_SIZE" "$AGING_ITERS" "$AGING_IO" "$SNAPSCALE_COUNT" \
+            "$CALIB_MIN_SEQ_MBPS" "$CALIB_MIN_RAND_IOPS"
+          mkdir -p results
+          cp -a "/var/lib/modern-fs-benchmark/results/$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT/${{ matrix.fs }}-${{ matrix.layout }}/." results/
 
       - name: Write job summary
         if: always()
@@ -131,56 +118,60 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: results-${{ matrix.fs }}-${{ matrix.layout }}
+          name: hardware-results-${{ matrix.fs }}-${{ matrix.layout }}
           path: results/
           if-no-files-found: ignore
 
   publish:
-    name: Store hosted results
+    name: Store hardware results
     needs: bench
-    if: ${{ !cancelled() && github.ref == 'refs/heads/main' }}
+    if: ${{ !cancelled() && needs.bench.result != 'skipped' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-26.04
     permissions:
       contents: write
     concurrency:
-      group: results-data
+      group: results-real-hw
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:
-          pattern: results-*
+          pattern: hardware-results-*
           path: incoming
           merge-multiple: true
 
-      # Failed matrix attempts may still reach publish; keep their partial
-      # artifacts out of history until a retry supplies the full matrix.
-      - name: Validate complete result set
+      - name: Validate complete hardware result set
         run: python3 scripts/validate-result.py --complete-set incoming/result-*.json
 
-      - name: Append results to history branch
+      - name: Verify hardware provenance
+        run: |
+          jq -e -s \
+            'all(.[]; (.devices | type == "string" and startswith("/dev/")))' \
+            incoming/result-*.json >/dev/null
+
+      - name: Append results to hardware history branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           set +e
-          git ls-remote --exit-code --heads origin results-data >/dev/null 2>&1
+          git ls-remote --exit-code --heads origin results-real-hw >/dev/null 2>&1
           status=$?
           set -e
           if [ "$status" -eq 0 ]; then
-            git fetch origin results-data
-            git worktree add data origin/results-data
-            git -C data checkout -B results-data
+            git fetch origin results-real-hw
+            git worktree add hardware-data origin/results-real-hw
+            git -C hardware-data checkout -B results-real-hw
           elif [ "$status" -eq 2 ]; then
-            git worktree add --detach data
-            git -C data checkout --orphan results-data
-            git -C data rm -rf --quiet . || true
+            git worktree add --detach hardware-data
+            git -C hardware-data checkout --orphan results-real-hw
+            git -C hardware-data rm -rf --quiet . || true
           else
-            echo "failed to query results-data (git exit $status)" >&2
+            echo "failed to query results-real-hw (git exit $status)" >&2
             exit "$status"
           fi
-          mkdir -p "data/runs/${{ github.run_number }}"
-          cp incoming/result-*.json "data/runs/${{ github.run_number }}/"
-          git -C data add runs
-          git -C data commit -m "results from run ${{ github.run_id }}" || echo "nothing new"
-          git -C data push origin results-data
+          mkdir -p "hardware-data/runs/${{ github.run_number }}"
+          cp incoming/result-*.json "hardware-data/runs/${{ github.run_number }}/"
+          git -C hardware-data add runs
+          git -C hardware-data commit -m "hardware results from run ${{ github.run_id }}" || echo "nothing new"
+          git -C hardware-data push origin results-real-hw

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,80 @@
+name: publish-pages
+
+on:
+  workflow_run:
+    workflows: [fs-bench, fs-bench-real-hw]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: write
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-26.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Check out hosted result history
+        run: |
+          git fetch origin results-data
+          git worktree add standard-data origin/results-data
+
+      - name: Check out hardware result history
+        run: |
+          set +e
+          git ls-remote --exit-code --heads origin results-real-hw >/dev/null 2>&1
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            git fetch origin results-real-hw
+            git worktree add hardware-data origin/results-real-hw
+          elif [ "$status" -eq 2 ]; then
+            mkdir -p hardware-data/runs
+          else
+            echo "failed to query results-real-hw (git exit $status)" >&2
+            exit "$status"
+          fi
+
+      - name: Build dashboards
+        run: |
+          python3 scripts/make-dashboard.py --runs standard-data/runs --out site/index.html \
+            --repo "https://github.com/${{ github.repository }}"
+          if compgen -G "hardware-data/runs/*/result-*.json" >/dev/null; then
+            python3 scripts/make-dashboard.py --runs hardware-data/runs --out site/real-hw/index.html \
+              --repo "https://github.com/${{ github.repository }}"
+          fi
+
+      - uses: actions/configure-pages@v6
+
+      - name: Drop stale pages artifacts from earlier attempts
+        run: |
+          for id in $(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
+                        --jq '.artifacts[] | select(.name == "github-pages") | .id'); do
+            gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/$id"
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -166,12 +166,63 @@ sudo BENCH_DEVICES="/dev/sdb /dev/sdc /dev/sdd /dev/sde" BENCH_WIPE=1 \
 Safety: devices must be unmounted, and anything carrying a filesystem
 signature is refused unless `BENCH_WIPE=1`. **Listed devices are wiped.**
 
-To drive real hardware from GitHub: register the machine as a
-[self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners),
-then trigger the workflow manually (`workflow_dispatch`) with `runs_on` set to
-your runner label and `devices` set to the disks to use. Scale up workload
-sizes via env (`SEQ_SIZE`, `AGING_SIZE`, `AGING_ITERS`, …) — CI defaults are
-sized for 4×16 GB loop files.
+For an unmanaged hardware run, invoke `scripts/run-bench.sh` directly with
+`BENCH_DEVICES`, `BENCH_SPARE_DEVICE`, and `BENCH_WIPE=1`. The dedicated
+self-hosted GitHub workflow instead requires the NixOS module below; it never
+accepts device paths from workflow inputs. Workload sizes can be adjusted with
+`SEQ_SIZE`, `AGING_SIZE`, `AGING_ITERS`, and the other documented environment
+variables. CI defaults are sized for 4×16 GB loop files.
+
+#### NixOS / deploy-rs
+
+This repository is also a flake with a reusable NixOS module and benchmark
+package. Cluster configurations can import `nixosModules.modern-fs-benchmark`;
+the module installs a dedicated Actions
+runner, the filesystem tools and matching out-of-tree modules for the
+cluster-selected kernel, and a restricted root wrapper with fixed device paths.
+It deliberately does not select a kernel or configure machine-wide boot,
+networking, users, or partitioning.
+
+```nix
+{
+  inputs.modern-fs-benchmark.url =
+    "github:fenio/modern-fs-benchmark";
+
+  # In the target node's modules list:
+  services.modern-fs-benchmark = {
+    enable = true;
+    repository = "https://github.com/fenio/modern-fs-benchmark";
+    tokenFile = "/run/secrets/modern-fs-benchmark-runner";
+    runnerName = "farm3";
+    runnerLabels = [ "fs-benchmark" ];
+    devices = [
+      "/dev/disk/by-partlabel/fsbench-nvme0-a"
+      "/dev/disk/by-partlabel/fsbench-nvme1-a"
+      "/dev/disk/by-partlabel/fsbench-nvme0-b"
+      "/dev/disk/by-partlabel/fsbench-nvme1-b"
+    ];
+    spareDevice = "/dev/disk/by-partlabel/fsbench-nvme0-spare";
+    zfsSingleDevice = "/dev/disk/by-partlabel/fsbench-nvme0-zfs-single";
+  };
+}
+```
+
+The four member devices and spare must each be exactly 16 GiB. The dedicated
+`zfsSingleDevice` must be exactly 32 GiB, matching the hosted-runner matrix.
+For an unregistered manual run, the same immutable package is available as
+`nix run .#manual -- <fs> <layout>`; provide the documented `BENCH_*`
+environment variables and run it as root.
+
+The master cluster flake owns the node assignment and deploy-rs deployment, so
+the runner can move to another machine without changing benchmark code. The
+dedicated `bench-real-hw.yml` workflow targets the `fs-benchmark` label and
+uses only the module's fixed devices. It publishes hardware history to
+`results-real-hw` and the dashboard under `/real-hw/`; the existing `bench.yml`
+workflow remains hosted-only and continues publishing `results-data` at the
+root dashboard. Hardware runs can be dispatched manually. The weekly schedule
+is enabled only when the repository variable `ENABLE_HARDWARE_BENCHMARKS` is
+set to `true`. The token file should contain a fine-grained PAT because
+ephemeral runners re-register after every job.
 
 **The plan is bigger than loop devices.** CI is the regression-tracking
 harness; the goal is to gather dedicated hardware and run the REAL tests

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Modern filesystem benchmark runner";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+      benchmarkFor = system:
+        import ./nix/benchmark-package.nix {
+          pkgs = nixpkgs.legacyPackages.${system};
+          source = self;
+        };
+    in
+    {
+      packages = forEachSystem (system: {
+        default = (benchmarkFor system).package;
+        benchmark = (benchmarkFor system).package;
+      });
+
+      apps = forEachSystem (system: {
+        default = self.apps.${system}.manual;
+        manual = {
+          type = "app";
+          program = "${self.packages.${system}.benchmark}/bin/modern-fs-benchmark";
+        };
+      });
+
+      nixosModules.default = import ./nix/module.nix { source = self; };
+      nixosModules.modern-fs-benchmark = self.nixosModules.default;
+    };
+}

--- a/nix/benchmark-package.nix
+++ b/nix/benchmark-package.nix
@@ -1,0 +1,48 @@
+{ pkgs, source, zfsPackage ? pkgs.zfs }:
+
+let
+  zvolId = pkgs.writeShellScriptBin "zvol_id" ''
+    exec ${zfsPackage}/lib/udev/zvol_id "$@"
+  '';
+
+  runtimeInputs = (with pkgs; [
+    bash
+    bc
+    bcachefs-tools
+    btrfs-progs
+    compsize
+    coreutils
+    cryptsetup
+    diffutils
+    e2fsprogs
+    findutils
+    fio
+    gawk
+    git
+    gnugrep
+    gnutar
+    gzip
+    jq
+    keyutils
+    kmod
+    lvm2
+    mdadm
+    procps
+    python3
+    systemd
+    util-linux
+    xfsprogs
+    zfsPackage
+  ]) ++ [ zvolId ];
+
+  package = pkgs.writeShellApplication {
+    name = "modern-fs-benchmark";
+    inherit runtimeInputs;
+    text = ''
+      exec ${source}/scripts/run-bench.sh "$@"
+    '';
+  };
+in
+{
+  inherit package runtimeInputs;
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,324 @@
+{ source }:
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.modern-fs-benchmark;
+
+  benchmark = import ./benchmark-package.nix {
+    inherit pkgs source;
+    zfsPackage = cfg.zfsPackage;
+  };
+  benchmarkPackages = benchmark.runtimeInputs;
+
+  allowedConfigurations = [
+    "ext4/single"
+    "ext4/md-raid10"
+    "ext4/lvm-raid10"
+    "ext4/md-raid6"
+    "ext4/md-raid10-luks"
+    "xfs/single"
+    "xfs/md-raid10"
+    "xfs/lvm-raid10"
+    "xfs/zvol"
+    "xfs/lvm-raid10-int"
+    "btrfs/raid1"
+    "btrfs/raid6"
+    "btrfs/single"
+    "btrfs/raid1-luks"
+    "zfs/mirror"
+    "zfs/mirror-8k"
+    "zfs/single"
+    "zfs/raidz1"
+    "zfs/raidz2"
+    "zfs/raidz1-enc"
+    "zfs/raidz2-enc"
+    "zfs/mirror-enc"
+    "bcachefs/replicas2"
+    "bcachefs/single"
+    "bcachefs/ec"
+    "bcachefs/replicas2-enc"
+  ];
+
+  runBenchmark = pkgs.writeShellApplication {
+    name = "modern-fs-benchmark-run";
+    runtimeInputs = benchmarkPackages;
+    text = ''
+      if [[ $# -ne 10 ]]; then
+        echo "usage: modern-fs-benchmark-run <run-id> <attempt> <fs> <layout> <dev-size> <aging-iters> <aging-io> <snap-count> <min-seq-mbps> <min-rand-iops>" >&2
+        exit 2
+      fi
+
+      run_id=$1
+      attempt=$2
+      fs=$3
+      layout=$4
+      dev_size=$5
+      aging_iters=$6
+      aging_io=$7
+      snap_count=$8
+      min_seq_mbps=$9
+      min_rand_iops=''${10}
+      configuration="$fs/$layout"
+
+      if [[ ! $run_id =~ ^[0-9]+$ || ! $attempt =~ ^[0-9]+$ ]]; then
+        echo "run ID and attempt must be numeric" >&2
+        exit 2
+      fi
+
+      case "$configuration" in
+        ${lib.concatStringsSep " | " allowedConfigurations}) ;;
+        *)
+          echo "unsupported benchmark configuration: $configuration" >&2
+          exit 2
+          ;;
+      esac
+
+      if [[ ! $dev_size =~ ^[1-9][0-9]*[KMGT]?$ || ! $aging_io =~ ^[1-9][0-9]*[KMGT]?$ ]]; then
+        echo "device and aging sizes must use fio size syntax" >&2
+        exit 2
+      fi
+      for value in "$aging_iters" "$snap_count" "$min_seq_mbps" "$min_rand_iops"; do
+        if [[ ! $value =~ ^[0-9]+$ ]]; then
+          echo "benchmark counts and calibration floors must be numeric" >&2
+          exit 2
+        fi
+      done
+
+      expected_dev_size=16G
+      expected_aging_iters=100
+      case "$configuration" in
+        ext4/lvm-raid10 | xfs/lvm-raid10 | xfs/lvm-raid10-int)
+          expected_aging_iters=8
+          ;;
+        xfs/zvol)
+          expected_aging_iters=25
+          ;;
+        zfs/single)
+          expected_dev_size=32G
+          expected_aging_iters=10
+          ;;
+        zfs/mirror-8k)
+          ;;
+        zfs/*)
+          expected_aging_iters=10
+          ;;
+      esac
+      if [[ $dev_size != "$expected_dev_size" || $aging_iters != "$expected_aging_iters" \
+            || $aging_io != 64M || $snap_count != 500 \
+            || $min_seq_mbps != 300 || $min_rand_iops != 8000 ]]; then
+        echo "benchmark settings do not match the reviewed workflow matrix" >&2
+        exit 2
+      fi
+
+      exec 9>/run/lock/modern-fs-benchmark.lock
+      if ! flock -n 9; then
+        echo "another filesystem benchmark is already running" >&2
+        exit 75
+      fi
+
+      require_size() {
+        local device=$1 expected=$2 actual
+        if [[ ! -b $device ]]; then
+          echo "$device is not a block device" >&2
+          exit 2
+        fi
+        actual=$(blockdev --getsize64 "$device")
+        if [[ $actual -ne $expected ]]; then
+          echo "$device has size $actual bytes; expected $expected" >&2
+          exit 2
+        fi
+      }
+
+      device_identities=
+      for device in ${lib.escapeShellArgs (cfg.devices ++ [ cfg.spareDevice cfg.zfsSingleDevice ])}; do
+        identity=$(stat -Lc '%t:%T' -- "$device")
+        case " $device_identities " in
+          *" $identity "*)
+            echo "$device resolves to a duplicate block device" >&2
+            exit 2
+            ;;
+        esac
+        device_identities+=" $identity"
+      done
+
+      for device in ${lib.escapeShellArgs (cfg.devices ++ [ cfg.spareDevice ])}; do
+        require_size "$device" 17179869184
+      done
+      require_size ${lib.escapeShellArg cfg.zfsSingleDevice} 34359738368
+
+      results_dir="/var/lib/modern-fs-benchmark/results/$run_id-$attempt/$fs-$layout"
+      install -d -m 0755 /var/lib/modern-fs-benchmark/results
+      rm -rf -- "$results_dir"
+      install -d -m 0755 "$results_dir"
+
+      export BENCH_DEVICES=${lib.escapeShellArg (lib.concatStringsSep " " cfg.devices)}
+      export BENCH_SPARE_DEVICE=${lib.escapeShellArg cfg.spareDevice}
+      export BENCH_ZFS_SINGLE_DEVICE=${lib.escapeShellArg cfg.zfsSingleDevice}
+      export BENCH_WIPE=1
+      export DEV_SIZE="$dev_size"
+      export AGING_ITERS="$aging_iters"
+      export AGING_IO="$aging_io"
+      export SNAPSCALE_COUNT="$snap_count"
+      export CALIB_MIN_SEQ_MBPS="$min_seq_mbps"
+      export CALIB_MIN_RAND_IOPS="$min_rand_iops"
+      export RESULTS_DIR="$results_dir"
+
+      ${benchmark.package}/bin/modern-fs-benchmark "$fs" "$layout"
+    '';
+  };
+in
+{
+  options.services.modern-fs-benchmark = {
+    enable = lib.mkEnableOption "the modern filesystem benchmark runner";
+
+    repository = lib.mkOption {
+      type = lib.types.str;
+      description = "GitHub repository whose Actions jobs this runner accepts.";
+    };
+
+    tokenFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to a GitHub runner PAT or registration token.";
+    };
+
+    runnerName = lib.mkOption {
+      type = lib.types.str;
+      default = config.networking.hostName;
+      description = "Name shown for the self-hosted GitHub runner.";
+    };
+
+    runnerLabels = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "fs-benchmark" ];
+      description = "Labels used to route benchmark jobs to this runner.";
+    };
+
+    runnerGroup = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Optional GitHub organization runner group restricted to trusted repositories.";
+    };
+
+    ephemeral = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Re-register a clean runner after every job; requires a PAT in tokenFile.";
+    };
+
+    devices = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "Four disposable block devices used as array members.";
+    };
+
+    spareDevice = lib.mkOption {
+      type = lib.types.str;
+      description = "Disposable block device used as the rebuild target.";
+    };
+
+    zfsSingleDevice = lib.mkOption {
+      type = lib.types.str;
+      description = "Dedicated 32 GiB block device used by zfs/single.";
+    };
+
+    enableBcachefs = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Build and load bcachefs for the cluster-selected kernel.";
+    };
+
+    enableZfs = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable ZFS support for the cluster-selected kernel.";
+    };
+
+    zfsPackage = lib.mkOption {
+      type = lib.types.package;
+      default = config.boot.zfs.package;
+      defaultText = lib.literalExpression "config.boot.zfs.package";
+      description = "Cluster-selected ZFS package exposed to benchmark jobs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = builtins.length cfg.devices == 4;
+        message = "services.modern-fs-benchmark.devices must contain exactly four devices";
+      }
+      {
+        assertion = cfg.spareDevice != "";
+        message = "services.modern-fs-benchmark.spareDevice must not be empty";
+      }
+      {
+        assertion = builtins.length (lib.unique (cfg.devices ++ [ cfg.spareDevice cfg.zfsSingleDevice ])) == 6;
+        message = "services.modern-fs-benchmark devices, spareDevice, and zfsSingleDevice must be distinct";
+      }
+    ];
+
+    boot.extraModulePackages =
+      lib.optional cfg.enableBcachefs config.boot.kernelPackages.bcachefs
+      ++ lib.optional cfg.enableZfs config.boot.zfs.modulePackage;
+    boot.kernelModules =
+      [ "dm_raid" "dm_snapshot" "dm_integrity" ]
+      ++ lib.optional cfg.enableBcachefs "bcachefs"
+      ++ lib.optional cfg.enableZfs "zfs";
+    services.udev.packages = lib.optional cfg.enableZfs cfg.zfsPackage;
+    users.groups.modern-fs-benchmark = { };
+    users.users.modern-fs-benchmark = {
+      isSystemUser = true;
+      group = "modern-fs-benchmark";
+    };
+
+    security.sudo.extraRules = [
+      {
+        users = [ "modern-fs-benchmark" ];
+        commands = [
+          {
+            command = "${runBenchmark}/bin/modern-fs-benchmark-run";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+      }
+    ];
+
+    services.github-runners.modern-fs-benchmark = {
+      enable = true;
+      url = cfg.repository;
+      tokenFile = cfg.tokenFile;
+      name = cfg.runnerName;
+      replace = true;
+      extraLabels = cfg.runnerLabels;
+      runnerGroup = cfg.runnerGroup;
+      ephemeral = cfg.ephemeral;
+      user = "modern-fs-benchmark";
+      group = "modern-fs-benchmark";
+      extraPackages = benchmarkPackages ++ [ runBenchmark ];
+      serviceOverrides = {
+        AmbientCapabilities = lib.mkForce null;
+        CapabilityBoundingSet = lib.mkForce null;
+        DeviceAllow = lib.mkForce null;
+        NoNewPrivileges = lib.mkForce false;
+        PrivateDevices = lib.mkForce false;
+        PrivateMounts = lib.mkForce false;
+        PrivateTmp = lib.mkForce false;
+        PrivateUsers = lib.mkForce false;
+        ProtectClock = lib.mkForce false;
+        ProtectControlGroups = lib.mkForce false;
+        ProtectHome = lib.mkForce false;
+        ProtectHostname = lib.mkForce false;
+        ProtectKernelLogs = lib.mkForce false;
+        ProtectKernelModules = lib.mkForce false;
+        ProtectKernelTunables = lib.mkForce false;
+        ProtectProc = lib.mkForce "default";
+        ProtectSystem = lib.mkForce false;
+        RemoveIPC = lib.mkForce false;
+        RestrictAddressFamilies = lib.mkForce null;
+        RestrictNamespaces = lib.mkForce false;
+        RestrictSUIDSGID = lib.mkForce false;
+        SystemCallFilter = lib.mkForce null;
+        UMask = lib.mkForce "0022";
+      };
+    };
+  };
+}

--- a/scripts/fs/btrfs.sh
+++ b/scripts/fs/btrfs.sh
@@ -18,7 +18,7 @@ fs_setup() {
     # raid1c3 metadata: parity-raid metadata is strongly discouraged
     # (write hole) — this is the pairing the btrfs docs recommend
     mkfs.btrfs -f -d raid6 -m raid1c3 "${DEVICES[@]}"
-    mount -o noatime "${DEVICES[0]}" "$MNT"
+    mount -t btrfs -o noatime "${DEVICES[0]}" "$MNT"
     btrfs subvolume create "$MNT/data"
     DATA="$MNT/data"
     return 0
@@ -31,7 +31,7 @@ fs_setup() {
   else
     mkfs.btrfs -f -d "$profile" -m "$profile" "${DEVICES[@]}"
   fi
-  mount -o noatime "${DEVICES[0]}" "$MNT"
+  mount -t btrfs -o noatime "${DEVICES[0]}" "$MNT"
   btrfs subvolume create "$MNT/data"
   DATA="$MNT/data"
 }
@@ -68,10 +68,10 @@ fs_degrade() {
   [ "${LAYOUT:-raid1}" != single ] || return 1
   umount "$MNT"
   if ! losetup -d "${DEVICES[1]}" 2>/dev/null; then
-    mount -o noatime "${DEVICES[0]}" "$MNT"
+    mount -t btrfs -o noatime "${DEVICES[0]}" "$MNT"
     return 1
   fi
-  mount -o degraded,noatime "${DEVICES[0]}" "$MNT"
+  mount -t btrfs -o degraded,noatime "${DEVICES[0]}" "$MNT"
 }
 
 fs_rebuild() {
@@ -88,7 +88,7 @@ fs_teardown() {
 
 fs_remount() {
   umount "$MNT"
-  mount -o noatime "${DEVICES[0]}" "$MNT"
+  mount -t btrfs -o noatime "${DEVICES[0]}" "$MNT"
 }
 
 fs_snap_list() { btrfs subvolume list "$MNT" >/dev/null; }

--- a/scripts/fs/ext4.sh
+++ b/scripts/fs/ext4.sh
@@ -20,7 +20,7 @@ fs_setup() {
       ;;
   esac
   mkfs.ext4 -Fq "$LAYERED_DEV"
-  mount -o noatime "$LAYERED_DEV" "$MNT"
+  mount -t ext4 -o noatime "$LAYERED_DEV" "$MNT"
   mkdir -p "$MNT/data"
   # shellcheck disable=SC2034  # consumed by run-bench.sh
   DATA="$MNT/data"

--- a/scripts/fs/xfs.sh
+++ b/scripts/fs/xfs.sh
@@ -10,6 +10,28 @@ source "$SCRIPT_DIR/lib/layered.sh"
 FS_REFLINK=1
 
 ZPOOL=fsbench
+ZVOL_DEV=
+
+zvol_resolve_device() {
+  local candidate name i
+  for i in $(seq 1 50); do
+    if [ -b "/dev/zvol/$ZPOOL/zvol" ]; then
+      echo "/dev/zvol/$ZPOOL/zvol"
+      return
+    fi
+    for candidate in /dev/zd*; do
+      [ -b "$candidate" ] || continue
+      name=$(zvol_id "$candidate" 2>/dev/null || true)
+      if [ "$name" = "$ZPOOL/zvol" ]; then
+        echo "$candidate"
+        return
+      fi
+    done
+    udevadm settle 2>/dev/null || true
+    sleep 0.1
+  done
+  die "ZFS volume $ZPOOL/zvol has no block device"
+}
 
 fs_setup() {
   if [ "${LAYOUT:-single}" = zvol ]; then
@@ -30,15 +52,16 @@ fs_setup() {
     zfs create -V "$(( avail * 3 / 4 ))" -o volblocksize=16k \
       -o refreservation=none "$ZPOOL/zvol"
     udevadm settle 2>/dev/null || sleep 2
-    mkfs.xfs -fq "/dev/zvol/$ZPOOL/zvol"
-    mount -o noatime "/dev/zvol/$ZPOOL/zvol" "$MNT"
+    ZVOL_DEV=$(zvol_resolve_device)
+    mkfs.xfs -fq "$ZVOL_DEV"
+    mount -t xfs -o noatime "$ZVOL_DEV" "$MNT"
     mkdir -p "$MNT/data"
     DATA="$MNT/data"
     return 0
   fi
   layered_make_dev
   mkfs.xfs -fq "$LAYERED_DEV"
-  mount -o noatime "$LAYERED_DEV" "$MNT"
+  mount -t xfs -o noatime "$LAYERED_DEV" "$MNT"
   mkdir -p "$MNT/data"
   # shellcheck disable=SC2034  # consumed by run-bench.sh
   DATA="$MNT/data"
@@ -79,7 +102,8 @@ fs_snapscale_delete() {
 fs_remount() {
   if zvol_case; then
     umount "$MNT"
-    mount -o noatime "/dev/zvol/$ZPOOL/zvol" "$MNT"
+    ZVOL_DEV=$(zvol_resolve_device)
+    mount -t xfs -o noatime "$ZVOL_DEV" "$MNT"
     return
   fi
   layered_remount
@@ -166,7 +190,8 @@ fs_drop_caches() {
     for d in "${DEVICES[@]}"; do args+=(-d "$d"); done
     zpool import "${args[@]}" "$ZPOOL"
     udevadm settle 2>/dev/null || sleep 2
-    mount -o noatime "/dev/zvol/$ZPOOL/zvol" "$MNT"
+    ZVOL_DEV=$(zvol_resolve_device)
+    mount -t xfs -o noatime "$ZVOL_DEV" "$MNT"
     return
   fi
   drop_caches

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -142,11 +142,15 @@ fs_version() { echo ""; }
 # Populate DEVICES[] — real devices from BENCH_DEVICES, or loop devices.
 setup_devices() {
   if [ -n "${BENCH_DEVICES:-}" ]; then
+    if [ "${FS:-}/${LAYOUT:-}" = zfs/single ] && [ -n "${BENCH_ZFS_SINGLE_DEVICE:-}" ]; then
+      BENCH_DEVICES=$BENCH_ZFS_SINGLE_DEVICE
+    fi
     read -ra DEVICES <<< "$BENCH_DEVICES"
     SPARE_DEV=${BENCH_SPARE_DEVICE:-}
     log "using real devices: ${DEVICES[*]}${SPARE_DEV:+ (spare: $SPARE_DEV)}"
-    local dev
-    for dev in "${DEVICES[@]}" ${SPARE_DEV:+"$SPARE_DEV"}; do
+    local dev real_devices=("${DEVICES[@]}")
+    [ -z "$SPARE_DEV" ] || real_devices+=("$SPARE_DEV")
+    for dev in "${real_devices[@]}"; do
       [ -b "$dev" ] || die "$dev is not a block device"
       if grep -q "^$dev " /proc/mounts || lsblk -no MOUNTPOINTS "$dev" | grep -q .; then
         die "$dev (or a partition on it) is mounted — refusing"
@@ -155,6 +159,12 @@ setup_devices() {
         die "$dev contains a filesystem/signature — set BENCH_WIPE=1 to allow wiping it"
       fi
     done
+    if [ "${BENCH_WIPE:-0}" = 1 ]; then
+      for dev in "${real_devices[@]}"; do
+        wipefs --all --force "$dev"
+      done
+      udevadm settle
+    fi
   else
     log "creating $NDEV loop devices of $DEV_SIZE (+1 spare) in $DISK_DIR"
     mkdir -p "$DISK_DIR"

--- a/scripts/lib/layered.sh
+++ b/scripts/lib/layered.sh
@@ -22,6 +22,9 @@ layered_make_dev() {
       LAYERED_DEV=/dev/md/fsbench
       ;;
     lvm-*)
+      modprobe dm_raid
+      modprobe dm_snapshot
+      case "$LAYOUT" in *-int) modprobe dm_integrity ;; esac
       # Each PV is wrapped in a dm-linear target so the degraded phase can
       # simulate a disk failure by swapping one wrapper to dm-error — the
       # same technique the lvm2 test suite uses (loop detach doesn't work:
@@ -77,7 +80,7 @@ layered_remount() {
   case "${LAYOUT:-single}" in
     lvm-*)
       umount "$MNT"
-      mount -o noatime "/dev/$VG/bench" "$MNT"
+      mount -t "$FS" -o noatime "/dev/$VG/bench" "$MNT"
       ;;
     *) return 1 ;;
   esac

--- a/scripts/result-schema.json
+++ b/scripts/result-schema.json
@@ -9,6 +9,7 @@
     "date": {"type": "string", "nonempty": true},
     "devices": {"type": "string", "nonempty": true},
     "ndev": {"type": "integer", "nonnegative": true},
+    "device_size_bytes": {"type": "integer", "nonnegative": true, "required": false},
     "calibration": {
       "type": "object",
       "properties": {

--- a/scripts/run-bench.sh
+++ b/scripts/run-bench.sh
@@ -707,6 +707,7 @@ fi
 
 # --- Assemble result -------------------------------------------------------
 write_result() {
+DEVICE_SIZE_BYTES=$(blockdev --getsize64 "${DEVICES[0]}")
 AGING_JSON=$(printf '%s\n' "${AGING_BW[@]}" | jq -s '.')
 if [ "${#SNAP_MS[@]}" -gt 0 ]; then
   # median, not mean — VM clock steps can corrupt individual samples
@@ -724,6 +725,7 @@ jq -n \
   --arg date "$(date -u +%FT%TZ)" \
   --arg devices "${BENCH_DEVICES:-loop}" \
   --argjson ndev "${#DEVICES[@]}" \
+  --argjson device_size_bytes "$DEVICE_SIZE_BYTES" \
   --argjson seqwrite_mbps "$SEQWRITE_MBPS" \
   --argjson randwrite_iops "$RANDWRITE_IOPS" \
   --argjson fsync_p99_ms "$FSYNC_P99_MS" \
@@ -785,7 +787,7 @@ jq -n \
   --argjson calib_randwrite_iops "$CALIB_RAND_IOPS" \
   '{schema_version: 4,
     fs: $fs, layout: $layout, kernel: $kernel, version: $version, date: $date,
-    devices: $devices, ndev: $ndev,
+    devices: $devices, ndev: $ndev, device_size_bytes: $device_size_bytes,
     calibration: {seqwrite_mbps: $calib_seqwrite_mbps,
                   randwrite_iops: $calib_randwrite_iops},
     results: {seqwrite_mbps: $seqwrite_mbps,

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+FLAKE = ROOT / "flake.nix"
+NIXOS_MODULE = ROOT / "nix" / "module.nix"
 FIXTURE_RUNS = ROOT / "tests" / "fixtures" / "runs"
 DASHBOARD = ROOT / "scripts" / "make-dashboard.py"
 AUDIT = ROOT / "scripts" / "audit-results.py"
@@ -20,6 +22,10 @@ BCACHEFS_BACKEND = ROOT / "scripts" / "fs" / "bcachefs.sh"
 BCACHEFS_DEBUG = ROOT / "scripts" / "lib" / "bcachefs-debug.sh"
 BCACHEFS_REPRO = ROOT / "scripts" / "repro-bcachefs-ec-evacuate.sh"
 BENCH_WORKFLOW = ROOT / ".github" / "workflows" / "bench.yml"
+HARDWARE_BENCH_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "bench-real-hw.yml"
+)
+PAGES_WORKFLOW = ROOT / ".github" / "workflows" / "publish-pages.yml"
 BCACHEFS_REPRO_WORKFLOW = (
     ROOT / ".github" / "workflows" / "repro-bcachefs-ec.yml"
 )
@@ -553,7 +559,30 @@ class ResultSchemaTests(unittest.TestCase):
             "validate-result.py --complete-set incoming/result-*.json",
             workflow,
         )
-        self.assertIn("name: Deploy dashboard\n    needs: publish", workflow)
+        self.assertIn("name: Store hosted results", workflow)
+        self.assertNotIn("actions/deploy-pages", workflow)
+
+    def test_hardware_results_use_separate_history_and_dashboard(self):
+        hosted = BENCH_WORKFLOW.read_text()
+        hardware = HARDWARE_BENCH_WORKFLOW.read_text()
+        pages = PAGES_WORKFLOW.read_text()
+
+        self.assertIn("git -C data push origin results-data", hosted)
+        self.assertNotIn("modern-fs-benchmark-run", hosted)
+        self.assertNotIn("BENCH_DEVICES", hosted)
+        self.assertIn("results-real-hw", hardware)
+        self.assertIn(
+            "git -C hardware-data push origin results-real-hw", hardware
+        )
+        self.assertIn('startswith("/dev/")', hardware)
+        self.assertNotIn("actions/deploy-pages", hardware)
+        self.assertIn("standard-data/runs", pages)
+        self.assertIn("hardware-data/runs", pages)
+        self.assertIn("site/real-hw/index.html", pages)
+        self.assertLess(
+            pages.index("actions/upload-pages-artifact"),
+            pages.index("actions/deploy-pages"),
+        )
 
     def test_unversioned_results_use_v1_contract(self):
         result = run_script(
@@ -772,6 +801,8 @@ class BackendConfigurationTests(unittest.TestCase):
         source = XFS_BACKEND.read_text()
 
         self.assertIn("-o refreservation=none", source)
+        self.assertIn("zvol_resolve_device", source)
+        self.assertIn('name=$(zvol_id "$candidate"', source)
 
     def test_bcachefs_ec_evacuation_is_bounded_and_diagnostic(self):
         backend = BCACHEFS_BACKEND.read_text()
@@ -803,6 +834,79 @@ class BackendConfigurationTests(unittest.TestCase):
             self.assertIn(command, reproducer)
         self.assertIn("workflow_dispatch", workflow)
         self.assertIn("if: always()", workflow)
+
+    def test_hardware_workflow_requires_managed_runner(self):
+        workflow = HARDWARE_BENCH_WORKFLOW.read_text()
+
+        self.assertIn("runs-on: [self-hosted, linux, x64, fs-benchmark]", workflow)
+        self.assertIn("modern-fs-benchmark-run", workflow)
+        self.assertIn("managed benchmark wrapper is not installed", workflow)
+        self.assertIn("$GITHUB_RUN_ID", workflow)
+        self.assertIn("/var/lib/modern-fs-benchmark/results/", workflow)
+        self.assertNotIn("scripts/install-deps.sh", workflow)
+        self.assertIn("ENABLE_HARDWARE_BENCHMARKS", workflow)
+
+    def test_hosted_and_hardware_workflows_use_same_matrix(self):
+        def matrix_profile(path):
+            workflow = path.read_text()
+            matrix = workflow[
+                workflow.index("      matrix:\n") : workflow.index("    env:\n")
+            ]
+            pattern = re.compile(
+                r"^\s+- fs: (\S+)\n\s+layout: (\S+)(.*?)"
+                r"(?=^\s+- fs:|\Z)",
+                re.MULTILINE | re.DOTALL,
+            )
+            profile = []
+            for fs, layout, options in pattern.findall(matrix):
+                dev_size = re.search(r"^\s+dev_size: (\S+)", options, re.MULTILINE)
+                aging = re.search(r"^\s+aging_iters: (\d+)", options, re.MULTILINE)
+                profile.append(
+                    (
+                        fs,
+                        layout,
+                        dev_size.group(1) if dev_size else "16G",
+                        int(aging.group(1)) if aging else 100,
+                    )
+                )
+            return profile
+
+        hosted = matrix_profile(BENCH_WORKFLOW)
+        hardware = matrix_profile(HARDWARE_BENCH_WORKFLOW)
+
+        self.assertEqual(len(hosted), 26)
+        self.assertEqual(hardware, hosted)
+
+    def test_nixos_module_keeps_machine_policy_in_cluster_configuration(self):
+        flake = FLAKE.read_text()
+        module = NIXOS_MODULE.read_text()
+
+        self.assertIn("nixosModules.modern-fs-benchmark", flake)
+        self.assertIn("config.boot.kernelPackages.bcachefs", module)
+        self.assertNotIn("linuxPackages_", module)
+        self.assertIn("devices must contain exactly four devices", module)
+        self.assertIn("modern-fs-benchmark-run", module)
+        self.assertIn('command = "${runBenchmark}/bin/', module)
+        self.assertIn("config.boot.zfs.package", module)
+        self.assertIn("config.boot.zfs.modulePackage", module)
+        self.assertIn('[ "dm_raid" "dm_snapshot" "dm_integrity" ]', module)
+        self.assertIn("another filesystem benchmark is already running", module)
+        self.assertIn("zfsSingleDevice", module)
+        self.assertIn("34359738368", module)
+        self.assertIn("resolves to a duplicate block device", module)
+        self.assertNotIn("boot.supportedFilesystems", module)
+        self.assertNotIn("results directory must be inside", module)
+        self.assertIn("packages =", flake)
+        self.assertIn("apps =", flake)
+
+    def test_real_device_validation_precedes_signature_wipe(self):
+        common = (ROOT / "scripts" / "lib" / "common.sh").read_text()
+
+        validation = common.index('[ -b "$dev" ]')
+        mount_check = common.index('is mounted — refusing')
+        wipe = common.index('wipefs --all --force "$dev"')
+        self.assertLess(validation, wipe)
+        self.assertLess(mount_check, wipe)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- export a reusable benchmark package and NixOS module for an ephemeral, fixed-device self-hosted runner
- split hosted and real-hardware benchmarks into separate workflows and history branches
- centralize Pages deployment so the root dashboard and `/real-hw/` are published atomically
- harden repeated hardware runs with validated signature wiping, exact device sizes, duplicate-device rejection, explicit filesystem mounts, LVM target loading, and robust zvol discovery

## Deployment
- hosted `bench.yml` remains loop-device-only and continues writing `results-data`
- `bench-real-hw.yml` targets `[self-hosted, linux, x64, fs-benchmark]` and writes `results-real-hw`
- the weekly hardware schedule stays disabled until `ENABLE_HARDWARE_BENCHMARKS=true`
- cluster deploy-rs configuration only needs to import `nixosModules.default` and provide its PAT secret and six partition paths

## Verification
- `python3 -m unittest discover -s tests` (41 tests)
- `nix flake check path:. --all-systems --no-build`
- full x86_64-linux NixOS module evaluation
- shell syntax and `git diff --check`
- actionlint passes apart from its label database not recognizing `ubuntu-26.04` and the project-specific `fs-benchmark` label
- complete 26-configuration farm3 hardware matrix validated on Linux 6.18.39 with 16 GiB members/spare and a 32 GiB zfs/single device

The manually collected hardware baseline is retained outside the Git branch and will be seeded into `results-real-hw` separately after review.