### PR TITLE
Fix managed hardware runner execution

### DIFF
--- a/.github/workflows/bench-real-hw.yml
+++ b/.github/workflows/bench-real-hw.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - fs: ext4

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -172,6 +172,9 @@ let
       ${benchmark.package}/bin/modern-fs-benchmark "$fs" "$layout"
     '';
   };
+  sudoShim = pkgs.writeShellScriptBin "sudo" ''
+    exec /run/wrappers/bin/sudo "$@"
+  '';
 in
 {
   options.services.modern-fs-benchmark = {
@@ -299,10 +302,10 @@ in
       ephemeral = cfg.ephemeral;
       user = "modern-fs-benchmark";
       group = "modern-fs-benchmark";
-      extraPackages = benchmarkPackages ++ [ runBenchmark ];
+      extraPackages = benchmarkPackages ++ [ runBenchmark sudoShim ];
       serviceOverrides = {
         AmbientCapabilities = lib.mkForce null;
-        CapabilityBoundingSet = lib.mkForce null;
+        CapabilityBoundingSet = lib.mkForce [ "~" ];
         DeviceAllow = lib.mkForce null;
         NoNewPrivileges = lib.mkForce false;
         PrivateDevices = lib.mkForce false;

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1072,6 +1072,7 @@ class BackendConfigurationTests(unittest.TestCase):
         self.assertIn("/var/lib/modern-fs-benchmark/results/", workflow)
         self.assertNotIn("scripts/install-deps.sh", workflow)
         self.assertIn("ENABLE_HARDWARE_BENCHMARKS", workflow)
+        self.assertIn("max-parallel: 1", workflow)
         for key, _label, _unit, _better in HARDWARE_METRIC_CONTRACT:
             self.assertIn(key, workflow)
 
@@ -1125,6 +1126,8 @@ class BackendConfigurationTests(unittest.TestCase):
         self.assertIn("resolves to a duplicate block device", module)
         self.assertIn("export BENCH_HARDWARE_RANDOM_SCALING=1", module)
         self.assertIn("hardware-random-scaling-v2", module)
+        self.assertIn('/run/wrappers/bin/sudo', module)
+        self.assertIn('CapabilityBoundingSet = lib.mkForce [ "~" ]', module)
         self.assertNotIn("BENCH_HARDWARE_RANDOM_SCALING", BENCH_WORKFLOW.read_text())
         self.assertNotIn("boot.supportedFilesystems", module)
         self.assertNotIn("results directory must be inside", module)


### PR DESCRIPTION
## Summary
- serialize the destructive real-hardware matrix on the single farm3 runner
- expose the NixOS sudo wrapper to runner jobs
- restore the capability bounding set needed by the reviewed root benchmark wrapper
- cover the runner policy with regression assertions

## Why
Run 30586896343 showed GitHub delivering a second matrix job while the prior worker was still active. Runner 2.335.1 cancelled the active worker, whose privileged child retained the hardware lock and caused cascading exit-75 failures. Earlier attempts also showed that sudo was absent from the runner PATH and had an empty capability bounding set.

## Validation
- 48 Python tests pass
- ShellCheck passes
- nix flake check --no-build passes
- git diff --check passes
- farm3 test activation confirms sudo, full capability bounding set, ZFS userland, and current-kernel module lookup without reboot