### PR TITLE
Dashboard: show kernel per table row

### DIFF
--- a/scripts/make-dashboard.py
+++ b/scripts/make-dashboard.py
@@ -390,6 +390,7 @@ def load_runs(runs_dir):
             entity = f"{doc['fs']}/{doc['layout']}"
             entry = dict(doc.get("results", {}))
             entry["calibration"] = doc.get("calibration")
+            entry["kernel"] = doc.get("kernel") or None
             entry["version"] = doc.get("version") or None
             results[entity] = entry
             dates.append(doc.get("date", ""))
@@ -1395,6 +1396,7 @@ const cols = [
    get: (e, r, c) => r.enospc_recover_ok == null ? null : (r.enospc_recover_ok ? "yes" : "NO")},
   {label: "calib seq", unit: "MB/s", get: (e, r, c) => c.seqwrite_mbps},
   {label: "calib rand", unit: "IOPS", get: (e, r, c) => c.randwrite_iops},
+  {label: "kernel", str: true, get: (e, r, c) => r.kernel},
   {label: "tools / module version", str: true, get: (e, r, c) => r.version},
 ];
 let sortCol = null, sortDir = 1;  // null = matrix order

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -177,6 +177,8 @@ class DashboardRegressionTests(unittest.TestCase):
         )
         latest = data["latest"]["results"]
         self.assertEqual(latest["ext4/single"]["seqwrite_mbps"], 510.2)
+        self.assertEqual(latest["ext4/single"]["kernel"], "6.17.0-fixture")
+        self.assertEqual(latest["bcachefs/replicas2"]["kernel"], "6.18.0-fixture")
         self.assertEqual(latest["btrfs/raid1"]["aging_mbps"], [42.0, 39.5, 37.0])
         self.assertIsNone(latest["zfs/mirror"]["reflink_ms"])
         self.assertIsNone(latest["bcachefs/replicas2"]["scrub_found"])
@@ -214,6 +216,7 @@ class DashboardRegressionTests(unittest.TestCase):
             html.index('content.appendChild(el("h2", {}, "Latest run"));'),
         )
         self.assertIn("Explore trends", html)
+        self.assertIn('label: "kernel"', html)
         self.assertIn("content.appendChild(buildExplorer(view));", html)
         self.assertIn(
             "https://cdn.jsdelivr.net/npm/echarts@6.0.0/dist/echarts.min.js",


### PR DESCRIPTION
Adds the kernel version to each row in the dashboard table.\n\nPreviously the page displayed only the latest run-level kernel in the header. The table now carries the kernel from each result JSON, so stale rows pulled from an earlier run show the kernel they were actually measured on.\n\nValidation:\n- python3 -m unittest tests/test_reporting.py\n- git diff --check